### PR TITLE
feat: add expand-tasks companion skill

### DIFF
--- a/companion-skills/expand-tasks/SKILL.md
+++ b/companion-skills/expand-tasks/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: expand-tasks
+description: >-
+  Expand all TaskMaster tasks with deep research via Perplexity before coding begins.
+  Reads tasks.json, launches parallel research agents per task, writes findings back.
+  Part of the prd-taskmaster toolkit. Use after PRD is parsed into tasks and before
+  implementation begins. Invoke with /expand-tasks or when user says "expand tasks",
+  "research all tasks", or "research before coding for all tasks".
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Task
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+# Expand Tasks with Research v1.0
+
+Expands TaskMaster tasks with Perplexity research before coding begins.
+Deterministic operations handled by `script.py`; AI handles judgment.
+
+**Script location**: `~/.claude/skills/expand-tasks/script.py`
+**Part of**: prd-taskmaster toolkit
+**Depends on**: research-before-coding skill (pattern), Perplexity MCP proxy
+
+## When to Use
+
+Activate when user says: expand tasks, research tasks, research before coding for all, expand subtasks.
+Do NOT activate for: single task research (use /research-before-coding), PRD generation (use /prd-taskmaster).
+
+## Prerequisites
+
+- TaskMaster tasks.json must exist (run /prd-taskmaster first)
+- Perplexity proxy must be running at localhost:8765
+- At least 1 task in tasks.json
+
+---
+
+## Workflow (5 Steps)
+
+### Step 1: Preflight
+
+```bash
+python3 ~/.claude/skills/expand-tasks/script.py read-tasks
+```
+
+Returns JSON: `total`, `expanded`, `pending_expansion`, `tasks[]`.
+
+**If `pending_expansion` is 0**: Report all tasks already expanded. Exit skill.
+
+**If Perplexity is down**: Check health first:
+```bash
+curl -sf http://localhost:8765/health
+```
+If down, tell user to start it and exit.
+
+---
+
+### Step 2: Choose Scope
+
+Use AskUserQuestion:
+- **All tasks** (default): Expand every task that hasn't been researched yet
+- **Specific tasks**: User provides task IDs (comma-separated)
+- **By dependency level**: Expand tasks with no dependencies first, then next wave
+
+**AI judgment**: Recommend "All tasks" for initial expansion, "By dependency level" for incremental work.
+
+---
+
+### Step 3: Generate Research Prompts
+
+For each task to expand:
+
+```bash
+python3 ~/.claude/skills/expand-tasks/script.py gen-prompt --task-id <ID>
+```
+
+Returns JSON with `prompt` field containing the full research agent prompt.
+
+**AI judgment**: Review the auto-generated prompt. Customize research questions if the task needs domain-specific queries. Add project context from the PRD or session-context files if relevant.
+
+---
+
+### Step 4: Launch Parallel Research Agents
+
+Launch research agents in parallel waves. Each wave = up to 5 concurrent agents.
+
+**For each task**, spawn a Task agent:
+
+```
+Task(
+  subagent_type: "general-purpose",
+  model: "sonnet",
+  description: "Research Task <ID>: <title>",
+  run_in_background: true,
+  prompt: <prompt from Step 3>
+)
+```
+
+**Wave strategy**:
+- Wave 1: Tasks with no dependencies (they inform downstream tasks)
+- Wave 2: Tasks depending on Wave 1
+- Wave 3+: Continue until all tasks covered
+- Max 5 agents per wave to avoid overwhelming Perplexity proxy
+
+**Wait for each wave to complete before launching the next.**
+
+---
+
+### Step 5: Collect and Write Results
+
+As each agent completes, save its research output:
+
+1. Write agent output to a temp file:
+   ```bash
+   echo "<agent output>" > /tmp/research-task-<ID>.md
+   ```
+
+2. Write research back to tasks.json:
+   ```bash
+   python3 ~/.claude/skills/expand-tasks/script.py write-research --task-id <ID> --research /tmp/research-task-<ID>.md
+   ```
+
+3. After all tasks are written, verify:
+   ```bash
+   python3 ~/.claude/skills/expand-tasks/script.py status
+   ```
+
+**AI judgment**: Review each research result for quality. If a result is too thin (< 5 lines of useful content) or clearly failed, re-run that specific task's research.
+
+---
+
+## Research Agent Prompt Pattern
+
+The `gen-prompt` command generates prompts that follow the research-before-coding pattern:
+
+1. Agent receives task context (title, description, dependencies, subtasks)
+2. Agent runs `perplexity_batch` or `mcp__perplexity-api-free__search` with 3-5 targeted queries
+3. Agent distills results into structured summary
+4. Summary returns to main context (~25-40 lines per task)
+
+**Critical**: Research agents must NEVER use WebSearch or WebFetch. Perplexity MCP only.
+
+---
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Perplexity proxy down | Exit skill, tell user to start proxy |
+| Agent returns empty/failed | Re-run that specific task with different queries |
+| tasks.json not found | Exit skill, tell user to run /prd-taskmaster first |
+| Task already expanded | Skip silently unless user forces re-expansion |
+| Agent timeout | Mark task as failed, continue with others |
+
+---
+
+## Output
+
+After all tasks are expanded, the skill reports:
+- Total tasks expanded
+- Any failures that need retry
+- Next recommended action (usually: begin implementation)
+
+---
+
+## Integration with prd-taskmaster
+
+This skill fits between Step 8 (Parse & Expand Tasks) and Step 11 (Choose Next Action) of the prd-taskmaster workflow. After PRD is parsed into tasks but before execution begins.
+
+```
+/prd-taskmaster → generates PRD → parses into tasks
+    ↓
+/expand-tasks → researches each task → writes findings back
+    ↓
+Implementation begins (with research context in each task)
+```
+
+---
+
+## Tips
+
+- Run after PRD generation but before any implementation
+- Research results are stored in `research_notes` field of each task in tasks.json
+- Re-running on already-expanded tasks is safe (will skip unless forced)
+- For very large task lists (20+), consider expanding in dependency order to save context
+- Each research agent costs ~30s of Perplexity time; 15 tasks ≈ 3 waves ≈ 2-3 minutes total

--- a/companion-skills/expand-tasks/script.py
+++ b/companion-skills/expand-tasks/script.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""
+expand-tasks script.py — Deterministic operations for TaskMaster task expansion.
+AI handles judgment (research questions, quality review); script handles mechanics.
+
+Commands:
+  read-tasks [--file PATH]           Read tasks.json and return task list
+  gen-prompt --task-id ID [--file PATH] [--prd PATH]  Generate research prompt for a task
+  write-research --task-id ID --research FILE [--file PATH]  Write research back to task
+  status [--file PATH]               Show expansion status (which tasks have research)
+"""
+
+import argparse
+import json
+import sys
+import os
+from pathlib import Path
+
+
+def find_tasks_file(explicit_path=None):
+    """Find tasks.json in the current project."""
+    if explicit_path:
+        p = Path(explicit_path)
+        if p.exists():
+            return p
+        print(json.dumps({"error": f"File not found: {explicit_path}"}))
+        sys.exit(1)
+
+    # Search common locations
+    candidates = [
+        Path(".taskmaster/tasks/tasks.json"),
+        Path("tasks/tasks.json"),
+    ]
+    for c in candidates:
+        if c.exists():
+            return c
+
+    print(json.dumps({"error": "No tasks.json found. Run from project root or use --file."}))
+    sys.exit(1)
+
+
+def load_tasks(tasks_file):
+    """Load and normalize tasks from tasks.json."""
+    with open(tasks_file) as f:
+        data = json.load(f)
+
+    # Handle nested structure: {master: {tasks: [...]}} or {tasks: [...]} or [...]
+    if isinstance(data, list):
+        return data, data
+    if isinstance(data, dict):
+        if "master" in data and isinstance(data["master"], dict):
+            return data["master"].get("tasks", []), data
+        if "tasks" in data:
+            return data["tasks"], data
+    return [], data
+
+
+def save_tasks(tasks_file, full_data, tasks):
+    """Save tasks back to tasks.json preserving structure."""
+    if isinstance(full_data, list):
+        full_data = tasks
+    elif isinstance(full_data, dict):
+        if "master" in full_data and isinstance(full_data["master"], dict):
+            full_data["master"]["tasks"] = tasks
+        elif "tasks" in full_data:
+            full_data["tasks"] = tasks
+
+    with open(tasks_file, "w") as f:
+        json.dump(full_data, f, indent=2)
+
+
+def cmd_read_tasks(args):
+    """Read and list all tasks."""
+    tasks_file = find_tasks_file(args.file)
+    tasks, _ = load_tasks(tasks_file)
+
+    result = []
+    for t in tasks:
+        has_research = bool(t.get("research_notes") or t.get("_research_expanded"))
+        deps = t.get("dependencies", [])
+        result.append({
+            "id": t.get("id"),
+            "title": t.get("title", ""),
+            "status": t.get("status", "pending"),
+            "dependencies": [str(d) for d in deps],
+            "has_research": has_research,
+            "description_length": len(t.get("description", "")),
+            "subtask_count": len(t.get("subtasks", [])),
+        })
+
+    print(json.dumps({
+        "tasks_file": str(tasks_file),
+        "total": len(result),
+        "expanded": sum(1 for r in result if r["has_research"]),
+        "pending_expansion": sum(1 for r in result if not r["has_research"]),
+        "tasks": result,
+    }, indent=2))
+
+
+def cmd_gen_prompt(args):
+    """Generate a research prompt for a specific task."""
+    tasks_file = find_tasks_file(args.file)
+    tasks, _ = load_tasks(tasks_file)
+
+    task = None
+    for t in tasks:
+        if str(t.get("id")) == str(args.task_id):
+            task = t
+            break
+
+    if not task:
+        print(json.dumps({"error": f"Task {args.task_id} not found"}))
+        sys.exit(1)
+
+    # Load PRD context if available
+    prd_context = ""
+    prd_path = args.prd or ".taskmaster/docs/prd.md"
+    if os.path.exists(prd_path):
+        with open(prd_path) as f:
+            prd_text = f.read()
+        # Extract relevant section (first 200 lines max)
+        lines = prd_text.split("\n")[:200]
+        prd_context = f"\n\nPRD CONTEXT (first 200 lines):\n{''.join(chr(10).join(lines))}"
+
+    # Build dependency context
+    dep_context = ""
+    deps = task.get("dependencies", [])
+    if deps:
+        dep_tasks = [t2 for t2 in tasks if str(t2.get("id")) in [str(d) for d in deps]]
+        if dep_tasks:
+            dep_lines = [f"- Task {t2['id']}: {t2.get('title', '')}" for t2 in dep_tasks]
+            dep_context = f"\n\nDEPENDENCY TASKS (must complete before this):\n" + "\n".join(dep_lines)
+
+    title = task.get("title", "")
+    description = task.get("description", "")
+    details = task.get("details", "")
+    subtasks = task.get("subtasks", [])
+
+    subtask_text = ""
+    if subtasks:
+        sub_lines = [f"- {s.get('title', s.get('id', ''))}" for s in subtasks]
+        subtask_text = f"\n\nSUBTASKS:\n" + "\n".join(sub_lines)
+
+    # Generate 5 research questions based on task content
+    research_questions = [
+        f"What are the current best practices for implementing {title} in 2026?",
+        f"What are common pitfalls and gotchas when building {title}?",
+        f"What libraries, frameworks, or tools are recommended for {title}?",
+        f"What architectural patterns work best for {title}?",
+        f"Are there open-source examples or references for {title}?",
+    ]
+
+    prompt = f"""You are expanding a TaskMaster task with research. DO NOT write any code or create files. ONLY research and return a structured summary.
+
+**Task {task.get('id')}: {title}**
+
+DESCRIPTION:
+{description}
+
+{f"DETAILS:{chr(10)}{details}" if details else ""}
+{subtask_text}
+{dep_context}
+
+Research these questions using Perplexity MCP tools (perplexity_batch preferred, perplexity_search as fallback):
+
+{chr(10).join(f"{i+1}. {q}" for i, q in enumerate(research_questions))}
+
+Return a structured summary with:
+- Key findings per question (2-3 sentences each)
+- Recommended implementation approach
+- Specific libraries/tools with versions
+- Code patterns to follow (max 15 lines each)
+- Pitfalls and warnings
+- Security considerations
+- Any conflicting advice between sources
+
+FORMAT your response as:
+---
+## Research: Task {task.get('id')} - {title}
+**Date**: YYYY-MM-DD
+
+### Key Findings
+[Numbered findings matching the research questions]
+
+### Recommended Approach
+- **Pattern**: [name]
+- **Libraries**: [with versions]
+- **Why**: [trade-off reasoning]
+
+### Key Code Pattern
+```[language]
+[Most relevant snippet, max 15 lines]
+```
+
+### Pitfalls
+- [Critical items to avoid]
+
+### Security Notes
+- [Any security considerations]
+
+### Implementation Guidance
+[2-4 sentences of specific implementation advice for this task]
+---"""
+
+    print(json.dumps({
+        "task_id": task.get("id"),
+        "title": title,
+        "prompt": prompt,
+        "research_questions": research_questions,
+    }, indent=2))
+
+
+def cmd_write_research(args):
+    """Write research results back into the task."""
+    tasks_file = find_tasks_file(args.file)
+    tasks, full_data = load_tasks(tasks_file)
+
+    # Read research content
+    if args.research == "-":
+        research_content = sys.stdin.read()
+    else:
+        with open(args.research) as f:
+            research_content = f.read()
+
+    # Find and update the task
+    updated = False
+    for t in tasks:
+        if str(t.get("id")) == str(args.task_id):
+            # Store research in the task
+            t["research_notes"] = research_content
+            t["_research_expanded"] = True
+
+            # Append research to details if it exists
+            existing_details = t.get("details", "")
+            if existing_details:
+                t["details"] = existing_details + "\n\n---\n\n" + research_content
+            else:
+                t["details"] = research_content
+
+            updated = True
+            break
+
+    if not updated:
+        print(json.dumps({"error": f"Task {args.task_id} not found"}))
+        sys.exit(1)
+
+    save_tasks(tasks_file, full_data, tasks)
+    print(json.dumps({
+        "success": True,
+        "task_id": args.task_id,
+        "research_length": len(research_content),
+        "tasks_file": str(tasks_file),
+    }))
+
+
+def cmd_status(args):
+    """Show expansion status."""
+    tasks_file = find_tasks_file(args.file)
+    tasks, _ = load_tasks(tasks_file)
+
+    expanded = []
+    pending = []
+    for t in tasks:
+        info = {"id": t.get("id"), "title": t.get("title", "")}
+        if t.get("research_notes") or t.get("_research_expanded"):
+            expanded.append(info)
+        else:
+            pending.append(info)
+
+    print(json.dumps({
+        "total": len(tasks),
+        "expanded": len(expanded),
+        "pending": len(pending),
+        "expanded_tasks": expanded,
+        "pending_tasks": pending,
+        "all_expanded": len(pending) == 0,
+    }, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="TaskMaster task expansion with research")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # read-tasks
+    p_read = subparsers.add_parser("read-tasks")
+    p_read.add_argument("--file", help="Path to tasks.json")
+
+    # gen-prompt
+    p_gen = subparsers.add_parser("gen-prompt")
+    p_gen.add_argument("--task-id", required=True, help="Task ID to generate prompt for")
+    p_gen.add_argument("--file", help="Path to tasks.json")
+    p_gen.add_argument("--prd", help="Path to PRD file")
+
+    # write-research
+    p_write = subparsers.add_parser("write-research")
+    p_write.add_argument("--task-id", required=True, help="Task ID to write research to")
+    p_write.add_argument("--research", required=True, help="Path to research file (or - for stdin)")
+    p_write.add_argument("--file", help="Path to tasks.json")
+
+    # status
+    p_status = subparsers.add_parser("status")
+    p_status.add_argument("--file", help="Path to tasks.json")
+
+    args = parser.parse_args()
+
+    if args.command == "read-tasks":
+        cmd_read_tasks(args)
+    elif args.command == "gen-prompt":
+        cmd_gen_prompt(args)
+    elif args.command == "write-research":
+        cmd_write_research(args)
+    elif args.command == "status":
+        cmd_status(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `expand-tasks` companion skill for research-based TaskMaster task expansion
- Reads tasks.json, launches parallel Perplexity research agents per task, writes findings back
- Includes `script.py` with 4 commands: `read-tasks`, `gen-prompt`, `write-research`, `status`
- Fits between PRD parsing (Step 8) and execution (Step 11) in the prd-taskmaster workflow

## Test plan
- [ ] Install skill to `~/.claude/skills/expand-tasks/`
- [ ] Run `python3 script.py read-tasks` against a project with tasks.json
- [ ] Run `python3 script.py gen-prompt --task-id 1` to verify prompt generation
- [ ] Invoke `/expand-tasks` in Claude Code session with active TaskMaster project
- [ ] Verify research results are written back to tasks.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)