### PR TITLE
release: 5.2.1 — pre-relaunch P0 hardening (first-run zero-key path)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Zero-config goal-to-tasks engine for Claude Code (the Atlas engine). Graded PRD validation, dependency-ordered task graph, and CDD-verified execution.",
   "author": {
     "name": "Atlas AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this project are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.1] — 2026-06-14
+
+Pre-relaunch hardening — fixes the first-run failures a multi-agent audit found
+on the documented zero-key path (and reproduced firsthand). See `docs/audit/`.
+
+### Fixed
+- **P0-1 — `configure-providers` now REPAIRS keyless stock defaults.** It previously
+  only filled *empty* model roles, so `task-master init`'s paid `anthropic`+`perplexity`
+  defaults survived untouched and a keyless first run produced **0 tasks**. It now
+  migrates any stock default whose provider is unusable in the current environment to
+  the available `claude`/`codex` CLI or the free local proxy (`KNOWN_STOCK_TASKMASTER_DEFAULTS`
+  + a `_provider_usable` check). Genuine user configs and usable configs are preserved;
+  the provider decision now dominates the tier decision.
+- **P0-2 — the SETUP gate (`validate_setup`) is credential-aware.** It reported
+  `ready=True` whenever a model-id *string* was present — green-lighting the exact
+  0-task config. It now verifies the configured provider is actually reachable
+  (key present / CLI on PATH).
+- **P0-3 — `expand` degrades to a structural pass when the research provider is down.**
+  Both the parallel and serial paths hardcoded `--research`; a quota/auth outage
+  hard-failed tasks to 0 subtasks. They now retry without `--research` (structural
+  expand is always available) and mark the result `degraded`.
+- **P1-1 — `parse_prd` reports `ok=False` on a 0-task parse** (was a silent success).
+- **Nested-session spawn probe (gh #11/#12).** When `main` is a CLI-spawning provider
+  inside a nested Claude Code session, the gate now *probes* whether the spawn works
+  rather than assuming — keeping the free path when it works and surfacing an
+  actionable error (never bare `--claude-code`) when it genuinely fails.
+- **Stale-tag detection (gh #13).** `preflight` now reports `current_tag_stale` +
+  `suggested_fresh_tag` so a new PRD is not parsed into a polluted, fully-done tag.
+
+### Changed
+- `package.json` now carries `author`, `homepage`, and `bugs` so the npm page is not
+  anonymous.
+
 ## [5.2.0] — 2026-06-13
 
 Progress visualization — the README/UX-SPEC panels are now real output.

--- a/docs/audit/AUDIT.md
+++ b/docs/audit/AUDIT.md
@@ -1,0 +1,188 @@
+# AUDIT.md — prd-taskmaster (Atlas) Engine, pre-relaunch 5.2.0
+
+**Auditor:** lead synthesis pass over 29 verified findings (refuted ones removed)
+**Repo audited:** `/home/anombyte/Shade_Gen/Projects/prd-taskmaster-public` @ HEAD `d506b93` (version **5.2.0**, published to npm)
+**Live dogfood consumer:** `/home/anombyte/Hermes/current-projects/shade-browser-mcp`
+**Context:** viral relaunch, 509 GitHub stars. A broken first run torches the goodwill.
+
+---
+
+## 1. Executive summary
+
+**HOLD the relaunch.** The engine's headline promise — *"zero setup, no paid API key, uses the model CLIs you already have"* — is **broken on the documented first-run path**, and the gate built to prevent exactly this **green-lights the broken state**.
+
+The root cause is a single causal chain, raised independently by multiple finders across the provider-config, skills, and dogfood-replay dimensions, and reproduced firsthand at HEAD `d506b93`:
+
+1. `task-master init` pre-populates all three model roles with **paid defaults** (`main=anthropic/claude-sonnet-4`, `research=perplexity/sonar`, `fallback=anthropic/claude-3-7-sonnet`).
+2. `configure-providers` is a **no-op** on populated roles — it only fills *empty* roles, so it never migrates a keyless `anthropic` role to the available `claude`/`codex` CLI, nor paid Perplexity to the free local proxy. The setup SKILL even instructs **SKIP** when roles are "populated with a supported provider."
+3. The **SETUP gate** reports `ready=True` because it checks only that a non-empty model-id *string* is present — never that the provider has a usable credential.
+
+Net effect: a brand-new user with `ANTHROPIC_API_KEY` unset follows the recommended path, the SETUP gate passes, and their first `parse-prd`/`expand` **silently produces 0 tasks**, then falls back to a degraded "Atlas Native Mode." A compounding 4th P0-class defect: when the research provider is **out of quota** (the actual dogfood condition), `expand` **hard-fails to 0 subtasks** and never degrades to the documented "always available" structural expand.
+
+A **237/318 all-green test suite shipped this** because it only covers the empty-role happy path. None of the three regression tests that would have caught the bug exist.
+
+**Verdict gate:** 3 P0s survive → **HOLD**. Ship only after the three P0 fixes plus three named regression tests are green.
+
+---
+
+## 2. Verdict
+
+| | |
+|---|---|
+| **Decision** | **HOLD** |
+| **P0 (relaunch blockers)** | **3** (deduplicated) |
+| **P1 (major)** | **8** |
+| **P2 (moderate)** | **6** |
+| **P3 (minor/polish)** | **4** |
+| **Rule** | HOLD because ≥1 P0 survives |
+| **Path to SHIP** | Land the 3 P0 fixes + 3 regression tests (Section 5), re-run full suite green, re-run the dogfood replay to `task_count>0` end-to-end |
+
+---
+
+## 3. Prioritized defect register
+
+> **De-duplication note.** The "configure no-op" root cause was raised by **five** finders across four dimensions (`configure-noop-on-populated-roles`, `configure-providers-noop-on-populated-paid-roles`, `configure-noop-on-stock-paid-defaults`, `setup-skill-skips-stock-paid-defaults`, `empty-role-configure-picks-native-correctly`). They are merged into **P0-1** with the others cited as corroboration. Likewise the "research prefers paid Perplexity on key presence" finding was raised three times (`research-real-api-if-key-...`, `research-prefers-paid-perplexity-on-key-presence-not-validity`, `research-prefers-paid-perplexity-on-key-presence`) and is merged into **P1-2**.
+
+### P0 — relaunch blockers (first run breaks)
+
+#### P0-1 · `configure-providers` is a no-op on TaskMaster's stock paid defaults → first run produces 0 tasks
+*(merges: configure-noop-on-populated-roles, configure-providers-noop-on-populated-paid-roles, configure-noop-on-stock-paid-defaults, setup-skill-skips-stock-paid-defaults, empty-role-configure-picks-native-correctly)*
+
+**Evidence (reproduced firsthand at HEAD d506b93):**
+- `prd_taskmaster/providers.py:55` `_role_empty()` returns `False` for any non-empty dict. Every model-role write is gated on it: `:176` (main), `:190` (fallback), `:207` (research). The only populated-main branch (`:180-187`) only re-tiers a `modelId` when start_tier≠standard AND the role is already a `KNOWN_ENGINE_DEFAULTS` value — it never changes `provider`, and under the default `balanced`/`standard` economy it never fires.
+- Live repro in `/tmp/audit_final` with stock paid config, `ANTHROPIC_API_KEY`+`PERPLEXITY_API_KEY` unset, **`claude` AND `codex` both on PATH**, proxy up:
+  ```
+  changed: ['.env:OPENAI_COMPATIBLE_API_KEY', '.env:PERPLEXITY_API_BASE_URL']
+  main:     {'provider': 'anthropic', 'modelId': 'claude-sonnet-4-20250514'}   # UNCHANGED
+  research: {'provider': 'perplexity', 'modelId': 'sonar'}                     # UNCHANGED
+  fallback: {'provider': 'anthropic', 'modelId': 'claude-3-7-sonnet-...'}      # UNCHANGED
+  ```
+  Zero model roles corrected despite no usable key and an available native CLI + free proxy.
+- End-to-end (separate finder): `init-taskmaster` → `configure-providers` → `parse-prd` in this env returns `{"ok": false, "task_count": 0}`, stderr `"Perplexity API error … Invalid API key"` and `Required API key ANTHROPIC_API_KEY … not set`; **tasks.json never created**.
+- The setup SKILL is wired to make this worse: `skills/setup/SKILL.md:126` table row `| Main / Research / Fallback all populated with a supported provider | SKIP — go to Step 4. |`, and `grep configure-providers skills/setup/SKILL.md` → **no matches** (the skill never even calls the repair command).
+- **Smoking gun:** emptying the three roles to `{}` first makes the identical configure run correctly pick `main→claude-code`, `fallback→codex-cli`. The *only* difference between broken and correct is whether roles were empty.
+
+**Contradicts:** `cli.py:178` help "Configure native TaskMaster providers and local Perplexity API Free"; `README.md:50` "configures it. Zero setup questions"; `README.md:89` "The free engine needs no paid API key — it uses the model CLIs you already have."
+
+**Fix:** Make configure **REPAIR, not just fill**. Define a "TaskMaster stock default" set (the exact init dicts) and treat those roles like empty ones — eligible for repopulation. Overwrite any role whose provider is unusable in the current env (`provider==anthropic` with `ANTHROPIC_API_KEY` unset; `provider==perplexity` with no/invalid key when the free proxy is up). Resolve the desired *usable* provider first, then apply tier on top of it (folds in P1-4). Preserve only genuinely user-customized non-default providers (openrouter, ollama, a key-bearing provider). Then change `skills/setup/SKILL.md` Step 3 to ALWAYS run `configure-providers` and reword the DETECT-FIRST table so "populated with an *unreachable* provider" is a CORRECT-not-skip case. **Verified:** a config with `main=claude-code` (+`fallback=codex-cli`) makes parse-prd return `ok:true/task_count>0` in the identical broken env.
+
+---
+
+#### P0-2 · SETUP gate `validate_setup` reports `ready=True` for the exact 0-task config — checks model-id string presence, never credential usability
+
+**Evidence (reproduced firsthand):**
+- `prd_taskmaster/mode_recommend.py:459` `provider_ok = bool(main_model)` — check 5 (provider_main) passes on any non-empty modelId string; `:480` (provider_research) is likewise `bool(research_model)`. A grep of the module for `API_KEY|getenv|os.environ|credential|reachable` inside the validation logic returns **zero** hits.
+- Live repro against the stock paid config with `ANTHROPIC_API_KEY` unset: `validate_setup()` → `ready: True critical_failures: 0`.
+- `prd_taskmaster/pipeline.py:90-93` gates the SETUP transition on `validate_setup.ready` AND `critical_failures==0`, so the gate built to prevent the 0-task failure **approves the precise config that produces it**.
+
+**Contradicts:** `skills/setup/SKILL.md:36` and `:195` ("Gate first, always") — the gate is presented as the guarantee that providers are configured.
+
+**Fix:** Add a credential-usability dimension to provider_main / provider_research / provider_fallback: if `provider==anthropic` require `ANTHROPIC_API_KEY` (else FAIL critical with fix "set ANTHROPIC_API_KEY or run configure-providers to switch to claude-code"); if `provider in {claude-code,codex-cli}` require the CLI on PATH; if `provider==perplexity` require a key (warn + suggest the free proxy if `127.0.0.1:8765` is reachable). The gate must verify the configured provider is reachable, not merely that a string is present.
+
+---
+
+#### P0-3 · `expand` hard-fails to 0 subtasks when the research provider is out of quota — never degrades to structural expand (THE dogfood failure)
+
+**Evidence (reproduced firsthand):**
+- `prd_taskmaster/tm_parallel.py:335` hardcodes the argv `[binary, "expand", "--id", str(task_id), "--research", "--force"]`. The retry in `_run_packet` (`:359-409`) only escalates tier via `shift_tier` — it re-runs the SAME `--research` command; **no structural (no-`--research`) attempt exists anywhere.**
+- `prd_taskmaster/backend.py:724` routes >3 pending tasks to this parallel path (the dogfood case has 5 tasks). The serial ≤3 path (`backend.py:742-771`) also has no structural retry.
+- `NativeBackend._expand_packet` (`backend.py:502-510`) is the same shape: only `kind=='invalid_json'` escalates; `rate_limit/quota/auth` LLMError hard-fails immediately.
+- Live repro with a fake `task-master` that fails iff `--research` is present: `ok=False`, `failed=[1,2,3,4,5]`, subtask counts `[0,0,0,0,0]`; the structural expand that would have succeeded was **never attempted**.
+
+**Contradicts:** `skills/generate/SKILL.md:276-277` documents `# Fallback: structural-only (still valuable; always available) task-master expand --all`; `skills/expand-tasks/SKILL.md:175` error row only says "Exit skill" on rate-limit. The "always available" fallback exists only in prose.
+
+**Fix:** On research-provider failure (timeout / non-zero exit / LLMError kind in `{rate_limit, quota, auth, no_key}`), retry the SAME expansion **without** `--research` before marking the task failed — add a final attempt dropping `--research` from `_run_one_attempt`'s argv, and a `research=False` structural retry in `NativeBackend._expand_packet` on non-`invalid_json` LLMError. Surface a `degraded=True` flag so the UX reports "expanded structurally (research unavailable)" instead of failing.
+
+---
+
+### P1 — major (silent wrong behavior / broken documented feature / risk)
+
+#### P1-1 · `parse-prd` reports `ok=true`/`task_count=0` (CLI exits 0) when the model produced zero tasks
+`backend.py:718-722` returns `{"ok": True, "task_count": len(tasks)}` on `returncode==0` with **no guard** that `len(tasks)>0`; `cli.py:87-89` exits 0 whenever `ok` is truthy. Reproduced live: fake parse-prd that warns to stderr and exits 0 → `ok:true, task_count:0, EXIT 0`. The only downstream defense is the GENERATE gate (`pipeline.py:100-101`), and `generate/SKILL.md:39-44` tells the agent to "proceed past this gate on first entry." **Fix:** treat `len(tasks)==0` on `returncode==0` as `ok=False` with an explanatory error; mirror in `NativeBackend.parse_prd`; stop documenting a gate bypass.
+
+#### P1-2 · `research_choice='real_api_if_key'` (balanced default) selects paid Perplexity on KEY PRESENCE over the available free local proxy, never validating the key
+*(merges three finder reports)* `providers.py:209-216`: the paid-Perplexity branch (`:211-212`) is evaluated **before** the `elif local_proxy_available` branch (`:215`); `_has_perplexity_api_key()` (`:125-129`) checks presence only. Reproduced: with `PERPLEXITY_API_KEY=pplx-JUNK` and proxy up, research→`perplexity/sonar` (paid); with the key unset, research→the free `openai-compatible` proxy. Fires only when the research role is empty (so latent behind P0-1, not the dogfood cause). **Fix:** when the free proxy answers a real 200 probe, prefer it unless the user explicitly opted into paid AND the key passes a validity probe.
+
+#### P1-3 · Zero provider credential validity/health check before writing config or before parse — presence is the only signal
+`has_anthropic_key` (`providers.py:171`) and `_has_perplexity_api_key` (`:125`) are pure presence checks; the local-proxy "availability" check (`:202-206`) trusts a URL substring OR a bare TCP-open (`lib.py:259`, no HTTP 200 probe); `backend.py:701-722` shells to the provider with no pre-flight and returns `task_count:0`+stderr on failure. Out-of-quota keys (the dogfood reality) are undetectable. **Fix:** add a lightweight health probe used by both configure (pre-write) and the SETUP gate (pre-parse): `which`+`--version` for CLIs, a real HTTP 200 for the proxy, at minimum key-format sanity (optionally a cheap auth ping) for paid APIs.
+
+#### P1-4 · The one branch that mutates a populated main role (tier-migration) keeps the unusable provider, only swaps modelId
+`providers.py:180-187` → `_main_model_for_start_tier` (`:114-122`) rewrites only `modelId` (provider preserved). Under `conservative` it turns a keyless `claude-sonnet-4` into a keyless `claude-haiku-4-5` — still anthropic, still no key. (One finder downgraded this to P2 because the branch is gated behind a non-default `conservative` economy nothing in the relaunch path selects, and the resulting state is equivalently-broken, not worse.) **Kept at P1 as part of the P0-1 fix scope:** when configure is made to repair, the provider decision must precede and dominate the tier decision. Folding it in costs nothing; shipping the repair without it reintroduces the keyless trap on non-default economies.
+
+#### P1-5 · Skills reference MCP tools that are not registered
+`tm_parse_prd` (`generate/SKILL.md:211`), `tm_analyze_complexity` (`generate/SKILL.md:225`), `update_pipeline_task_status` (`execute-task/SKILL.md:207`) — none appear in `server.py`'s 33 registered tools (correct names: `parse_prd`, `rate_tasks`, `set_task_status`). An agent following the documented MCP fallback calls a tool that does not exist. (One finder downgraded to P2 since these are labeled "fallback" beneath working CLI primary paths and FastMCP returns a loud not-found error, not silent corruption.) **Fix:** rename in skills, or add thin alias tools in `server.py`.
+
+#### P1-6 · `execute-task` Step 10c pipeline-consistency write is broken on BOTH branches
+Primary path calls unregistered `mcp__plugin_prd_go__update_pipeline_task_status` (`execute-task/SKILL.md:207`); the documented fallback points to `mcp-server/pipeline.py:locked_update()` which **does not exist** (real module is `prd_taskmaster/pipeline.py`; `locked_update` lives in `prd_taskmaster/lib.py:78`); the fallback also writes a `phase_evidence.EXECUTE.tasks_completed` key no code reads. The step that exists to keep `pipeline.json` and `tasks.json` consistent has no executable path — `pipeline.json` silently drifts. **Fix:** add an `update_pipeline_task_status(task_id, status)` tool delegating to `prd_taskmaster/pipeline.py`, or rewrite Step 10c onto `advance_phase`/`log_progress` and fix the module path.
+
+#### P1-7 · Concurrent `apply_results`/`write_atomic` on tasks.json loses updates AND crashes (FileNotFoundError)
+`parallel.py:84` uses a FIXED tmp name (`path.with_suffix(".json.tmp")`, not pid-unique) and an unlocked read-modify-write (`:125-182`). The correct primitives exist unused (`lib.py:73` pid-suffixed `atomic_write`, `lib.py:78` flock `locked_update`). A 60-run two-thread repro produced 9 lost-update runs and 48 `FileNotFoundError` runs. (One finder downgraded to P3 on the grounds that no shipped engine path invokes `apply_results` concurrently — fan-out is research-only, the apply is single-threaded post-join, fleet workers use isolated worktrees.) **Kept at P1** because the CLI exposes `apply`/`inject` subcommands and the module docstring falsely claims "single-writer safety preserved"; the fix is cheap (route through `lib.atomic_write` + `lib.locked_update`) and removes a latent corruption class. Treat as P1-to-fix / P3-to-block: do not let it block the relaunch on its own, but land it with the cluster.
+
+#### P1-8 · `configure-providers` falsely reports `local_perplexity_api_free:true` while research still points at paid Perplexity
+`providers.py:250-251` emits `local_perplexity_api_free` from `local_proxy_available` (`:202-206`, mere reachability), **decoupled** from whether the research role was actually set to the proxy. A consumer/agent trusting the flag believes research is free+working when it is paid — masks the failure. (One finder downgraded to P2: the field is diagnostic-only with no programmatic reader, and on a *clean* stock config the `.env`-write the finding cited does not fire.) **Fix:** only report `true` when `models['research']` is actually the local proxy (check the role dict's own baseURL, not the env-var fallback).
+
+---
+
+### P2 — moderate (degraded UX / fragile / missing fallback)
+
+- **P2-1 · `expand --no-research` and `expand --id` silently ignored when >3 tasks pending.** `backend.py:724-731` calls `tm_parallel.run_tm_parallel(tag=tag)` dropping both `research` and `task_ids`; the serial ≤3 path honors them (`backend.py:744-746`). A fresh viral PRD almost always yields >3 tasks, so the first real run takes the parallel path that hardcodes `--research` — eliminating the one escape hatch precisely when P0-3 bites. **Fix:** thread `research` down to `_run_one_attempt`'s argv and add task selection to `run_tm_plan` (note: `run_tm_parallel`'s signature currently accepts *neither* — full plumbing required, not just arg forwarding).
+- **P2-2 · `package.json` postinstall silently pip-installs into the user's active Python env.** `package.json:26` `pip install -r mcp-server/requirements.txt 2>/dev/null || echo WARN`. On PEP-668 distros (Debian 12+/Ubuntu 23.04+/Fedora) this fails with `externally-managed-environment`, swallowed by `2>/dev/null`; the MCP server then can't import `mcp`/`fastmcp` at runtime. Reproduced on this box (has the EXTERNALLY-MANAGED marker). **Fix:** don't auto-pip in postinstall; print the exact venv/pipx command, detect PEP-668, and drop `2>/dev/null` so failure is visible.
+- **P2-3 · Engine writes `.env` but never adds `.env`/`.taskmaster/` to `.gitignore`.** `providers.py:223-241` writes `.env`; grep finds zero `.gitignore` writers in the engine. Protection is inherited from `task-master init`, and even that covers `.env` but not `.taskmaster/`. In a repo with a pre-existing hand-rolled `.gitignore`, the engine-created `.env` (and any real keys the user adds beside the dummy) is one `git add .` away from being committed. **Fix:** idempotently ensure `.env` and `.taskmaster/` are in `.gitignore` whenever the engine writes them.
+- **P2-4 · Local proxy research role is incompatible with task-master `--research` parse path (envelope shape mismatch).** Proxy returns a bare `{tasks:[...]}` body; task-master's openai-compatible adapter expects `{choices:[{message:{content}}]}` → `AI_TypeValidationError … path ["choices"]`. Degraded-not-fatal (falls through to fallback) and the engine's default parse-prd doesn't pass `--research`, but `expand`/`rate` do route to the research role. **Fix:** have the proxy emit a proper OpenAI chat-completions envelope (durable), or guard expand/rate away from the proxy.
+- **P2-5 · `handoff` skill calls `script.py append-workflow`/`debrief`/`handoff-gate` — none exist as CLI subcommands.** `cli.py` DISPATCH has none; verified `invalid choice`. They exist only as MCP tools; `handoff-gate` exists nowhere ("(when implemented)" shipped in `handoff/SKILL.md:341`). MCP-mode works; the documented CLI fallback is dead. **Fix:** add the CLI subcommands as thin wrappers, or relabel as MCP-only with a real inline fallback; implement or remove `handoff-gate`.
+- **P2-6 · Test suite encodes the no-op as desired behavior / has no coverage for stock-default correction.** `test_dogfood_fixes.py:174-189` asserts a populated role "is not touched"; no test seeds the stock anthropic/perplexity/anthropic trio keyless and asserts correction. (One finder corrected the mechanism claim — stock anthropic IS in `KNOWN_ENGINE_DEFAULTS` so it doesn't share the exact branch the test covers — and downgraded the "green bar certifies 0-tasks" thesis; the residual coverage gap is real and is folded into Section 5.)
+
+### P3 — minor / polish
+
+- **P3-1 · SHIP_CHECK_OK Gate-5 override is a hardcoded plaintext constant** (`skel/ship-check.py:57` `OVERRIDE_TOKEN="SHIP_CHECK_OVERRIDE_ADMIN"`). The gates themselves are genuinely unfakable; the override is audit-logged + marked `[OVERRIDE]` and is never auto-supplied (not reachable on a first run). README never claims the token is secret. **Fix (optional):** move the override behind an env-set secret/nonce; clarify wording.
+- **P3-2 · `package.json` missing `author`/`bugs`/`homepage`** (confirmed: all three `None` at 5.2.0). The npm page 509 stars land on shows no author byline and no "Report issues" link. **Fix:** mirror the three fields from `.claude-plugin/plugin.json`.
+- **P3-3 · `install.sh --with-taskmaster` runs `npm install -g task-master-ai`** (the interactive default is YES). Bounded, gated, reversible; `curl|bash` skips it via the `! -t 0` guard. (Title's "pip side-effects" is unsupported — no pip in install.sh.) **Fix:** default the prompt to N; surface that it's a global install.
+- **P3-4 · MCP prefix divergence** (`mcp__plugin_prd_go__` hardcoded in skills/hooks). Empirically verified CORRECT for plugin `prd`+server `go` (commit `9c44027`); mitigated by ToolSearch discovery preferring `mcp__atlas-engine__`. Residual polish: re-verify against a clean `/plugin install prd`.
+- **P3-5 · parse-prd failure passes through task-master stderr** — the PRD-leak actually goes to STDOUT (which `parse_prd`'s error dict discards), so the named vector is inert in the dogfood replay. No action required beyond optional redaction in the expand `stdout` path.
+
+---
+
+## 4. Ordered fix plan (what to fix first to unblock relaunch)
+
+**Fix 1 — Make `configure-providers` REPAIR keyless stock defaults (closes P0-1, folds in P1-4).**
+In `run_configure_providers`: add a `KNOWN_STOCK_TASKMASTER_DEFAULTS` set (the exact init dicts). Treat a role as correctable when it is empty OR a stock default whose provider is unusable in the current env (anthropic w/o key, perplexity w/o valid key while proxy up). Resolve the desired *usable* provider first (claude-code/codex-cli when CLI present + no key; free proxy for research when a 200 probe passes), THEN apply tier on top of that provider. Then edit `skills/setup/SKILL.md` Step 3 to ALWAYS run configure-providers and fix the DETECT-FIRST table so "unreachable provider" ≠ SKIP.
+
+**Fix 2 — Make the SETUP gate credential-aware (closes P0-2).**
+In `mode_recommend.validate_setup`, replace `provider_ok = bool(main_model)` with reachability checks per provider type (key present for anthropic/perplexity, CLI on PATH for claude-code/codex-cli, 200 probe for the proxy). A keyless paid stack must produce a critical failure with an actionable fix string.
+
+**Fix 3 — Add structural fallback to `expand` on research-provider failure (closes P0-3).**
+In `tm_parallel._run_one_attempt`/`_run_packet` add a final attempt dropping `--research`; in `NativeBackend._expand_packet` add a `research=False` retry on non-`invalid_json` LLMError. Surface `degraded=True`. This is the single highest-leverage fix for the most common first-run outage.
+
+**Fix 4 — Quota/validity-aware research routing + honest reporting (closes P1-2, P1-3, P1-8).**
+Add the shared health probe (P1-3); prefer the free proxy over an unvalidated paid key (P1-2); only report `local_perplexity_api_free:true` when the research role IS the proxy (P1-8).
+
+**Fix 5 — parse-prd zero-task = failure (closes P1-1).**
+Return `ok=False` on `returncode==0` with `len(tasks)==0`; stop documenting the GENERATE-gate bypass.
+
+**Fix 6 — Skill/MCP plumbing (closes P1-5, P1-6, P2-5).**
+Rename the three dead tool refs; add `update_pipeline_task_status` + the `append-workflow`/`debrief` CLI subcommands (or fix the docs + module paths); implement or remove `handoff-gate`.
+
+**Fix 7 — Hygiene + polish (P1-7, P2-1, P2-2, P2-3, P3-2).**
+Route parallel writes through `lib.atomic_write`+`lib.locked_update`; forward `--no-research`/`--id` through the parallel path; replace the postinstall auto-pip with an informational message; ensure `.gitignore` entries; add npm metadata.
+
+**Re-gate before SHIP:** full suite green + the three regression tests below + a clean dogfood replay (`init → configure → parse → expand`) reaching `task_count>0` and non-zero subtasks with `ANTHROPIC_API_KEY` unset and Perplexity out-of-quota.
+
+---
+
+## 5. Tests that must be added (the coverage gaps that let this ship)
+
+A 237/318 all-green suite shipped a guaranteed-broken first run because it only exercises the empty-role happy path. Gate the relaunch on these going green:
+
+1. **Stock-default correction (catches P0-1, P1-4, P2-6).** Seed `{main:anthropic/claude-sonnet-4, research:perplexity/sonar, fallback:anthropic/claude-3-7-sonnet}` with `ANTHROPIC_API_KEY`/`PERPLEXITY_API_KEY` unset and `claude` CLI + local proxy available. Assert configure-providers rewrites `main→claude-code`, `fallback→codex-cli`, `research→openai-compatible` local proxy. Repeat under `conservative` economy and assert provider is corrected before tier. Also update `test_configure_providers_user_configured_main_is_not_touched` to seed an actually-usable (key-bearing) provider, not a keyless paid one.
+
+2. **Credential-aware SETUP gate (catches P0-2).** With the stock paid config and no keys, assert `validate_setup().ready == False` and `critical_failures > 0` with a provider-credential failure naming the fix.
+
+3. **Research-failure structural degradation (catches P0-3).** Fake `task-master` that fails iff `--research` is present and succeeds structurally. Assert `expand` still lands subtasks via a no-`--research` retry, returns `ok=True`, and marks `degraded=True`. Cover both the parallel (>3 tasks) and serial (≤3) paths.
+
+4. **parse-prd zero-task = failure (catches P1-1).** Fake parse-prd that exits 0 without writing tasks. Assert `parse_prd` returns `ok=False`. Mirror for `NativeBackend`.
+
+5. **Research routing prefers free proxy / validates key (catches P1-2, P1-8).** Empty research role + an exhausted/garbage `PERPLEXITY_API_KEY` + proxy up: assert research resolves to the free proxy (or paid only after a validity probe) and that `local_perplexity_api_free` is reported `true` ONLY when the role is the proxy.
+
+6. **Concurrent apply integrity (catches P1-7).** Two-thread/two-process `apply_results` for different ids: assert both ids' subtasks survive and no `FileNotFoundError`.
+
+> The unifying lesson: every existing provider test asserts "we don't touch the user's config" against an *empty* or *user-customized* baseline. None assert "we CORRECT a keyless stock default" — which is the exact production state `task-master init` creates. The relaunch's stability depends on inverting that test bias.

--- a/docs/audit/RELAUNCH-READINESS.md
+++ b/docs/audit/RELAUNCH-READINESS.md
@@ -1,0 +1,150 @@
+# Relaunch Readiness — prd-taskmaster (Atlas) v5.2.0
+
+**Audited:** 2026-06-14 · HEAD `d506b93` · published to npm as `prd-taskmaster`
+**Lens:** go-to-market / first-impression readiness for a FREE viral relaunch (Reddit + npm, 509 GitHub stars). The bar is **"does a brand-new user's first run succeed, and do the README's headline promises hold on a clean machine?"** — not "can I charge."
+**Method:** read the actual repo (README, install.sh, package.json, root SKILL.md, skills/setup/SKILL.md, prd_taskmaster/), ran the engine on a clean dir, probed the live `atlas-ai.au/install` endpoint, npm-packed the tarball. Cross-checked against the engineering `defect-register.json` (21 confirmed defects, 3 P0).
+
+---
+
+## Verdict
+
+**Relaunch readiness: 41 / 100 — NO-GO as written.**
+
+The deterministic core is genuinely good and the npm tarball is clean. But the **single most-traveled first-run path — the one the README actively steers viral users onto — ends in zero tasks with a green "ready" status and no actionable error.** That is the worst possible outcome for a goodwill-driven launch: it doesn't error loudly (which a user forgives), it silently produces nothing (which a user screenshots and posts as "this is broken").
+
+**Two of the three relaunch-killers are go-to-market issues the engineering register under-weights:**
+1. The README's own quickstart *funnels users into the broken backend* (not just "a bug exists somewhere").
+2. The headline "no paid API key, uses the CLIs you already have" is **literally false on the default auto-selected path** once a user does what the README tells them to.
+
+One focused day of work flips this to GO.
+
+---
+
+## 1. The install → first-success funnel (step count + drop-offs)
+
+There are **two install paths and two run paths**, and they don't behave the same — confusion vector #1.
+
+### Path A — one-liner (`curl -fsSL https://atlas-ai.au/install | bash`)
+Live and correct: endpoint returns HTTP 200, served `VERSION="5.2.0"` matches the repo. But it is **CLI-only** — `install.sh` does NOT pip-install the MCP deps and does NOT register the MCP server (verified: zero `pip`/`requirements`/`claude mcp`/`server.py` references in install.sh). So the "32 MCP tools" surface is dark after the one-liner; the skills fall back to CLI mode, which works.
+
+### Path B — Claude Code plugin (`/plugin install prd`)
+The MCP server (`mcp-server/server.py:22` → `from mcp.server.fastmcp import FastMCP`) is **silently dead** unless the user already has `mcp`/`fastmcp` in their Python env. No `npm postinstall` runs for a `/plugin` install, and **nothing in the plugin quickstart tells plugin users to pip-install the deps.** Not fatal (CLI fallback works) but the headline MCP feature is invisible with no remediation documented. (Not in the defect register — a pure GTM gap.)
+
+### The run funnel (5 phases)
+`SETUP → DISCOVER → GENERATE → HANDOFF → EXECUTE`, driven by `/atlas` (root `SKILL.md`, runs inline) or `/prd:go` (`skills/go/SKILL.md`, routes to per-phase skills). User-prompt count to first `tasks.json`: **0 (setup) → N adaptive interview questions + 1 approval (discover) → ~0 (generate) → 1 mode pick (handoff).** Reasonable on paper.
+
+**Drop-off points, in order of likelihood:**
+1. **The TaskMaster zero-tasks trap (see §3) — the dominant bounce.** Highest probability, worst symptom: silent zero, green status.
+2. **Phase-0 gate "known issue."** Every phase skill (`setup/SKILL.md:36-44`, and discover/generate/handoff) documents that `check_gate` is wired as an entry gate but is structurally an exit gate, so on first entry `evidence={}` **fails by design**, and the skill instructs the agent to "proceed past this gate on first entry." A literal-minded model stops here. Fragile and model-dependent.
+3. **Plugin MCP silently dead (Path B).** Feature appears broken; user doesn't know to pip-install.
+4. **Python 3.11+ hard requirement** (`README.md:89`) — older-python boxes bounce at import.
+
+**Time-to-first-task on the happy native path:** plausibly the advertised ~90s. **On the README-recommended path (TaskMaster installed): never — 0 tasks.**
+
+---
+
+## 2. README honesty — which specific claims are false on a fresh box
+
+> **`README.md:89-91` / `:210-211`:** "The free engine needs **no paid API key** — it uses the model CLIs you already have."
+> **`README.md:78`, `:138-142`, `:216`:** repeatedly encourages `npm install -g task-master-ai` "to unlock the TaskMaster backend."
+
+These two claims are jointly false in the most common configuration, because of the backend auto-selector:
+
+```python
+# prd_taskmaster/backend.py:820-833  get_backend()
+backend = config.get("backend", "auto")          # default is "auto"
+...
+taskmaster_backend = TaskMasterBackend(_FACTORY_TOKEN)
+if taskmaster_backend.detect().get("available"):  # TaskMaster on PATH? it WINS.
+    return taskmaster_backend
+return NativeBackend()
+```
+
+Verified live on a clean dir with `task-master-ai` present:
+```
+backend-detect → "selected": "taskmaster", "source": "auto"
+```
+
+So: the README tells the user to install `task-master-ai`; the moment they do, **auto-selection abandons the native (genuinely-keyless) path and routes them onto TaskMaster's stock paid Anthropic/Perplexity defaults** — which need keys the user was told they don't need. The "no paid API key" promise holds *only* on the native backend, which the README's own advice causes the user to leave.
+
+> **`README.md:50`:** "Preflight … configures it. **Zero setup questions.**"
+
+Technically true, materially misleading: it configures it *into a non-working state* on the TaskMaster path (§3) and then reports success.
+
+> **`README.md:33` / `:106-112`:** the `Grade: GOOD … 14 tasks parsed` and the GENERATE panel mockups.
+
+These are aspirational mockups, not captured output. Fine for marketing, but they set an expectation ("14 tasks parsed") that the broken path directly contradicts ("0 tasks parsed, ok:true").
+
+**Honest claims that DO hold:** MIT/free-forever; the deterministic PRD grader + placeholder scan; vendor-neutral `tasks.json`; the `SHIP_CHECK_OK` gate; Python/POSIX platform requirements; the pre-alpha framing (the README is admirably candid about "not battle-tested," which buys real goodwill).
+
+---
+
+## 3. The relaunch-killer, end to end (the bug a viral visitor will hit)
+
+A confirmed chain, each link verified in code and reproduced in the defect register:
+
+1. User reads README → installs `task-master-ai` as encouraged (`README.md:78`).
+2. `get_backend()` auto-selects **taskmaster** (`backend.py:820-833`, reproduced above).
+3. `task-master init` writes **populated** stock paid roles (keyless `anthropic` main / paid `perplexity` research).
+4. `configure-providers` is a **no-op** on those: every role write is gated on `_role_empty` (`providers.py:55` → `not isinstance(value, dict) or not value`) at `:176/:190/:207`. Non-empty stock dicts ⇒ "not empty" ⇒ never migrated to the keyless `claude-code`/`codex-cli` providers the engine prefers. (`defect-register.json` P0-1, live-reproduced: `changed=['.env:…']`; main/research/fallback ALL unchanged.)
+5. The SETUP gate green-lights it: `validate_setup` does `provider_ok = bool(main_model)` (`mode_recommend.py:459`) — **string presence, zero credential check.** Reports `ready=True` for the exact config that yields nothing. (P0-2)
+6. `parse-prd` returns `ok:false / task_count:0`, `tasks.json` never created — and the CLI **exits 0** anyway (P1-1, `backend.py:718-722`), so even a scripting user sees "success."
+
+**Net first-run experience:** green "Setup ready" panel → adaptive interview → "0 tasks parsed" with no error the user can act on. This is the screenshot that torches a Reddit launch.
+
+(The *native* keyless path actually works: `NativeBackend.parse_prd` returns a structured `agent_action_required` with a schema hint and steps for the agent to parse inline — `backend.py:344-349`, `_agent_parse_action:249`. The tragedy is that auto-selection + the README's advice steer users away from the one path that honors the headline.)
+
+---
+
+## 4. The npm package as a first impression
+
+The tarball itself is **clean and professional** — `npm pack --dry-run`: **151.7 kB packed / 515.4 kB unpacked / 64 files.** No leaks: `AUDIT.md`, `defect-register.json`, `.env`, `docs/`, `tests/`, `__pycache__` are all correctly excluded by the `files` allowlist. All `files`-array entries exist.
+
+But the **registry page metadata is degraded** (verified against current `package.json`):
+- `author` — **MISSING** (`.claude-plugin/plugin.json` has "Atlas AI"; root package.json doesn't).
+- `bugs` — **MISSING** → no "Report issues" link on the npm page.
+- `homepage` — **MISSING** → no homepage link (plugin.json has the GitHub URL; package.json doesn't).
+
+For a project trying to look credible to 509 stars' worth of inbound traffic, an npm page with **no author byline, no homepage, no issues link** reads as anonymous/abandoned. (P3-2.) Trivial to fix; high first-impression leverage.
+
+Secondary npm-page risk — **`postinstall` (`package.json:26`)**: it `pip install`s into the user's active Python env and swallows failure with `2>/dev/null`. Verified the **PEP-668 `EXTERNALLY-MANAGED` marker is present on a standard Arch box**, so this install **fails on every modern Debian/Ubuntu/Arch/Fedora distro** — silently. Good news (verified): the **core CLI path is stdlib-only** (`prd_taskmaster/` has zero `mcp`/`fastmcp` imports; `from prd_taskmaster.cli import main` imports clean with no deps). So the postinstall failure is **cosmetic to first-run, fatal only to MCP mode.** But a swallowed-error postinstall during `npm install` still looks broken and erodes trust on the very first command.
+
+---
+
+## 5. The ONE fix that most increases viral-success odds
+
+**Make the backend default keyless-correct, not the README.** Specifically: change `configure-providers` from *fill-empty* to *repair*, so that when TaskMaster's stock keyless `anthropic`/`perplexity` defaults are present and unusable in-env, they are **migrated to `claude-code`/`codex-cli`** (which the code already prefers — see `_desired_main_model`, providers.py:64). This is exactly `defect-register.json` P0-1's fix.
+
+Why this one: it is the root of the entire zero-tasks chain (§3), it makes the README's headline promise *true* instead of requiring a README walk-back, and it's the difference between "0 tasks, green status" and "14 tasks parsed" on the path real users will take. Pair it with the P0-2 credential-usability check in `validate_setup` so the gate can never again green-light a zero-yield config. Together these two are < 1 day and flip the dominant first-run from failure to success.
+
+If only **one line** could change before launch and nothing else: in `get_backend()` (backend.py:822) **default to `native` unless the user explicitly opted into taskmaster** — the native path honors the keyless promise today and sidesteps the entire P0 chain. (Less complete than fixing configure-providers, but the cheapest possible de-risk.)
+
+---
+
+## 6. Relaunch go / no-go and the fastest path to "just works"
+
+**Decision: NO-GO as written. One day of work → GO.**
+
+Do not post to Reddit/npm-announce until the dominant first-run produces > 0 tasks on a keyless box. The fastest credible path (priority-ordered by first-run impact, not engineering elegance):
+
+| # | Fix | File / evidence | Why it gates launch | Effort |
+|---|-----|-----------------|---------------------|--------|
+| 1 | `configure-providers`: repair stock keyless defaults → claude-code/codex-cli (don't just fill-empty) | `providers.py:55,176,190,207`; P0-1 | Root of the zero-tasks chain; makes "no paid key" true | ~4h |
+| 2 | `validate_setup`: add credential-usability checks (CLI on PATH / key present / proxy 200), fail loudly | `mode_recommend.py:459`; P0-2 | Stops the gate green-lighting a 0-yield config | ~2h |
+| 3 | `parse-prd`: treat `task_count==0` on rc 0 as `ok:false` with an actionable error | `backend.py:718-722`, `cli.py:87`; P1-1 | Turns silent-zero into a fixable error | ~1h |
+| 4 | README: stop steering keyless users to `task-master-ai`; make clear native is the default and keyless; or default `get_backend()` to native | `README.md:78,138-142`; `backend.py:822` | Aligns the funnel with the working path | ~1h |
+| 5 | `package.json`: add `author`, `bugs`, `homepage` (mirror plugin.json) | `package.json`; P3-2 | The npm page 509 stars land on | ~10m |
+| 6 | `postinstall`: drop `2>/dev/null`, detect PEP-668, print the exact pipx/venv command instead of auto-pip | `package.json:26`; P2-2 | Stops a silent-fail first command on every modern distro | ~30m |
+| 7 | Plugin path: document the pip-install step for MCP deps (or lazy-import + graceful CLI fallback message) | `.mcp.json`, `server.py:22` | Plugin users' headline MCP feature isn't silently dark | ~1h |
+
+**Items 1–4 are the launch gate.** 5–7 are same-day polish that materially improve the first impression.
+
+**Acceptance proof before GO:** on a clean box with `ANTHROPIC_API_KEY` unset, `task-master-ai` installed, and only `claude` on PATH — run `/atlas` end to end and observe `tasks.json` with **> 0 tasks** and a status panel that reports the *real* keyless provider. Capture that run. If it still shows 0 tasks or a false-green, it is still NO-GO.
+
+---
+
+## Self-check
+- Every claim above cites a file:line or a reproduced command. Verified live: backend auto-selects taskmaster; CLI imports without mcp/fastmcp; PEP-668 marker present; author/bugs/homepage missing; `atlas-ai.au/install` HTTP 200 serving v5.2.0; npm tarball clean at 151.7 kB.
+- Score (41) is consistent with the NO-GO call: a confirmed P0 chain that breaks the headline promise on the dominant path caps relaunch readiness regardless of how good the core is.
+- Nothing scored "works" that is actually mocked: the native keyless path is real (`agent_action_required`); the failure is that auto-selection + README route users off it.
+- Explorer pane killed.

--- a/docs/audit/TEST_CONTRACT.md
+++ b/docs/audit/TEST_CONTRACT.md
@@ -1,0 +1,38 @@
+# TEST_CONTRACT.md — prd-taskmaster (Atlas) engine
+
+Behavioral contract the test suite is responsible for proving. Audited at HEAD ~d506b93
+(version 5.2.0) on 2026-06-14. Suite executed: `python3 -m pytest tests/ -q` -> **318 passed**;
+`python3 -m pytest tests/core -q` -> **237 passed** (the remaining ~81 live under tests/mcp,
+tests/plugin, tests/integration). The suite is fully green while the documented first-run
+zero-config path ships broken.
+
+Evidence strength legend: `none` (no executable check) | `weak` (test exists but would still
+pass if the behavior broke) | `partial` (real behavior asserted, key paths uncovered) |
+`strong` (asserts observable behavior, fails when the claim is false, executed fresh in this audit).
+
+| # | Claim the engine makes | Verification command | Evidence |
+|---|---|---|---|
+| C1 | configure-providers corrects a keyless/paid stock default to an available CLI or the free proxy so first run yields tasks | `python3 -m pytest tests/core/test_dogfood_fixes.py -q` + keyless-stock repro | **none** |
+| C2 | validate_setup reports ready=True only when the provider can actually produce tasks (credential usable) | `python3 -m pytest 'tests/core/test_capabilities.py::TestValidateSetup' -q` | **weak** |
+| C3 | expand degrades to structural (no --research) on research quota/auth failure ("always available") | `python3 -m pytest tests/core/test_tm_parallel.py tests/core/test_backend.py -q` | **weak** (anti-regression lock present) |
+| C4 | parse-prd returns ok=false when zero tasks were produced | `python3 -m pytest tests/core/test_backend.py -q -k parse_prd` | **partial** |
+| C5 | research selection validates the Perplexity key before preferring paid over the free proxy | `python3 -m pytest tests/core/test_dogfood_fixes.py -q -k research` | **weak** |
+| C6 | a credential validity/health probe runs before writing config / before parse | `grep -rn 'health\|probe\|200' tests/core/` | **none** |
+| C7 | the parallel expand path (>3 pending) honors research choice and task ids | `python3 -m pytest tests/core/test_backend.py::test_expand_delegates_to_tm_parallel_for_more_than_three_pending -q` | **weak** |
+| C8 | the suite covers correction of a keyless stock default (not just leave-config-alone) | `grep -rn 'claude-sonnet-4-20250514\|claude-3-7-sonnet' tests/` (0 hits) | **none** |
+| C9 | route_task picks per-task models from complexity and falls back on missing backend | `python3 -m pytest tests/core/test_model_routing.py -q` | **strong** (but NOT a first-run-path claim) |
+| C10 | NativeBackend no-key path returns agent_action_required | `python3 -m pytest tests/core/test_native_backend.py -q` | **partial** (wrong backend vs. the shipped path) |
+
+## The one-line summary of why a green suite shipped a broken product
+
+The suite asserts **"do not touch user config"** against **EMPTY** roles (`{}`) and **user-CUSTOM**
+providers (`provider: "openai"`), and asserts **"setup is ready"** against **model-id strings with
+no provider field**. It never once asserts **"CORRECT a keyless stock default"** or **"a string
+present is not the same as a credential that works."** The bug lives precisely in the gap between
+"config is shaped right" (tested) and "config can actually produce tasks" (never tested).
+
+## Contract status: NOT MET for relaunch
+
+C1, C2, C3 are the three P0 claims behind the guaranteed-broken first run. None is currently
+proven; C3 is actively LOCKED in its broken state by a passing test. These must reach `strong`
+before the viral relaunch. See `recommended-test-tasks.md`.

--- a/docs/audit/claim-evidence-matrix.json
+++ b/docs/audit/claim-evidence-matrix.json
@@ -1,0 +1,112 @@
+[
+  {
+    "claim": "configure-providers migrates an unusable provider (keyless anthropic / paid perplexity) to an available CLI (claude/codex) or the free local proxy so the first run produces tasks",
+    "source": "prd_taskmaster/providers.py:151-254 run_configure_providers; advertised by setup skill + README zero-config promise; defect-register P0-1",
+    "expectedBehavior": "Given .taskmaster/config.json with the stock task-master init trio (main=anthropic/claude-sonnet-4-20250514, research=perplexity/sonar, fallback=anthropic/claude-3-7-sonnet-20250219), ANTHROPIC_API_KEY and PERPLEXITY_API_KEY unset, claude+codex on PATH, configure-providers REWRITES main to claude-code/codex and research to the local proxy. With no CLI either, it surfaces a critical error rather than silently leaving paid keyless defaults.",
+    "existingCoverage": "tests/core/test_dogfood_fixes.py:113 (seeds claude-code/sonnet, a USABLE provider), :140/:157 (seed EMPTY {} research role), :174 (seeds provider=openai user-custom, asserts NOT touched), :215 (seeds EMPTY {}). None seed the keyless anthropic stock trio.",
+    "verificationCommand": "python3 -m pytest tests/core/test_dogfood_fixes.py -q ; plus repro: seed stock keyless config, run providers.run_configure_providers(economy='balanced') with shutil.which patched to None",
+    "evidenceStrength": "none",
+    "riskIfFalse": "Every stranger who installs via npm/install.sh with ANTHROPIC_API_KEY unset gets 0 tasks on first run — the headline zero-config promise fails at the viral relaunch. configure-providers is a no-op because _role_empty (providers.py:55) returns False for the pre-populated paid roles; gating at :176/:190/:207 skips all rewrites.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "The SETUP gate (validate_setup) reports ready=True only when the configured provider can actually produce tasks",
+    "source": "prd_taskmaster/mode_recommend.py:359-511 validate_setup; pipeline.py gates SETUP->DISCOVER on ready+0 critical; defect-register P0-2",
+    "expectedBehavior": "validate_setup() on a keyless anthropic stock config returns ready=False with a critical failure naming the missing credential. It must verify credential/CLI usability, not mere model-id string presence.",
+    "existingCoverage": "tests/core/test_capabilities.py:203 test_validate_setup_passes_with_full_project asserts ready=True for config {main:{modelId:'claude-sonnet-4-5'}} with NO provider field and NO credential; :232 critical_failures_count; pipeline gate tests test_pipeline_state.py:46,51 only feed a literal {ready:True}.",
+    "verificationCommand": "python3 -m pytest 'tests/core/test_capabilities.py::TestValidateSetup' -q ; plus repro driving validate_setup() against keyless stock config",
+    "evidenceStrength": "weak",
+    "riskIfFalse": "The gate that is supposed to block a broken setup actively certifies the 0-task config as ready. Live repro: ready=True, critical_failures=0 on keyless stock paid config. provider_ok=bool(main_model) (mode_recommend.py:459) checks string presence only; zero credential/env checks exist in the module.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "expand degrades to structural expand (no --research) when the research provider fails on quota/auth/no-key, so subtasks are still produced (generate/SKILL.md:276-277 'structural always available')",
+    "source": "prd_taskmaster/tm_parallel.py:335 (_run_one_attempt hardcodes --research); backend.py:744-746 serial path; backend.py:727 parallel path; defect-register P0-3",
+    "expectedBehavior": "When `task-master expand --id N --research` fails specifically because research is unavailable (rate_limit/quota/auth/no_key), the engine retries the SAME task WITHOUT --research before declaring failure, and surfaces degraded=True. Subtasks > 0 on a research-only failure.",
+    "existingCoverage": "tests/core/test_tm_parallel.py:184 test_tm_run_failure_retries_with_escalated_config — fake fails on ANY expand (mode='fail', :30-33) regardless of --research; asserts attempts==2 and failed==[1], codifying that the retry re-runs --research and still fails. tests/core/test_backend.py:180 test_expand_serial_branch pins commands to exactly [expand,--id,N,--research]. test_native_backend.py:204 escalates only invalid_json, not research failure.",
+    "verificationCommand": "python3 -m pytest tests/core/test_tm_parallel.py tests/core/test_backend.py::test_expand_serial_branch_runs_binary_and_appends_telemetry -q",
+    "evidenceStrength": "weak",
+    "riskIfFalse": "First real run on a fresh PRD (>3 tasks -> parallel path) hard-fails to 0 subtasks the moment research quota/auth fails — the exact dogfood failure. The serial-path test is worse than absent: it is an ANTI-REGRESSION LOCK. Mutation proof: adding a structural fallback (dropping --research) turns test_expand_serial_branch RED, so the fix is blocked by a passing test.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "parse-prd reports failure (ok=false) when the model produced zero tasks",
+    "source": "prd_taskmaster/backend.py:718-722 (returns ok=True,task_count=len(tasks) with no len>0 guard); cli.py exits 0 when ok truthy; defect-register P1-1",
+    "expectedBehavior": "TaskMasterBackend.parse_prd on a returncode==0 run that wrote zero tasks returns ok=False with an explanatory error; CLI exits non-zero.",
+    "existingCoverage": "tests/core/test_backend.py:144 test_parse_prd_runs_taskmaster_and_counts_tasks_json (count=5 only); :245 test_taskmaster_responses_carry_backend_identity (returncode=1 failure only). No test with returncode==0 and 0 tasks.",
+    "verificationCommand": "python3 -m pytest tests/core/test_backend.py -q -k parse_prd",
+    "evidenceStrength": "partial",
+    "riskIfFalse": "A model that warns-to-stderr and exits 0 with zero tasks is reported as success; downstream gate (GENERATE) is documented as bypassable on first entry, so 0 tasks flows through silently.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "research_choice 'real_api_if_key' validates the Perplexity key before preferring paid Perplexity over the available free local proxy",
+    "source": "prd_taskmaster/providers.py:209-216 (paid branch evaluated before local_proxy elif); _has_perplexity_api_key presence-only (:125-129); defect-register P1-2",
+    "expectedBehavior": "With an empty research role, a junk PERPLEXITY_API_KEY, and the free proxy reachable, configure prefers the proxy unless the key passes a validity probe.",
+    "existingCoverage": "tests/core/test_dogfood_fixes.py:140/:157 seed empty role + a key and assert paid sonar/sonar-pro is chosen — i.e. they ASSERT the presence-only behavior is correct. No test seeds a junk key with proxy up.",
+    "verificationCommand": "python3 -m pytest tests/core/test_dogfood_fixes.py -q -k research",
+    "evidenceStrength": "weak",
+    "riskIfFalse": "Users with a stale/quota-exhausted Perplexity key get paid research selected over a working free proxy, then expand/rate hard-fail. Latent behind P0-1 (only fires on empty research role).",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "There is a provider credential validity/health check before writing config or before parse",
+    "source": "providers.py:171/:125 presence-only; lib local-proxy availability is substring-OR-bare-TCP (no HTTP 200); backend shells with no pre-flight; defect-register P1-3",
+    "expectedBehavior": "A shared health probe (which+--version for CLIs, real HTTP 200 for proxy, key sanity/auth ping for paid APIs) runs before configure writes and before parse.",
+    "existingCoverage": "none — no test asserts any reachability/validity probe; local_proxy_available is asserted true purely from the 127.0.0.1:8765 URL substring in test_dogfood_fixes.py:215-237.",
+    "verificationCommand": "grep -rn 'health\\|probe\\|reachab\\|200' tests/core/ (no credential-validity assertions found)",
+    "evidenceStrength": "none",
+    "riskIfFalse": "Out-of-quota / invalid keys (the dogfood reality) are undetectable; the engine writes a config it cannot use.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "The parallel expand path (>3 pending) honors the --research / --no-research choice and the requested task ids",
+    "source": "backend.py:724-731 calls tm_parallel.run_tm_parallel(tag=tag) dropping research and task_ids; serial path (:744-746) honors them; defect-register P2-1",
+    "expectedBehavior": "expand(task_ids=[2], research=False) with >3 pending threads research=False and task selection into the parallel run.",
+    "existingCoverage": "tests/core/test_backend.py:160 test_expand_delegates_to_tm_parallel_for_more_than_three_pending asserts only called['tag']=='master'; it captures **kwargs but never asserts research or task_ids were passed — it passes whether or not they are dropped.",
+    "verificationCommand": "python3 -m pytest tests/core/test_backend.py::test_expand_delegates_to_tm_parallel_for_more_than_three_pending -q",
+    "evidenceStrength": "weak",
+    "riskIfFalse": "A fresh viral PRD usually yields >3 tasks -> parallel path -> the --no-research escape hatch is silently ignored exactly when P0-3 bites; the test would pass even after the drop.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "The test suite covers correction of a keyless stock default (not just leave-user-config-alone)",
+    "source": "defect-register P2-6; tests/core/test_dogfood_fixes.py overall",
+    "expectedBehavior": "A test seeds the keyless anthropic/perplexity/anthropic stock trio and asserts configure-providers corrects it to a usable provider.",
+    "existingCoverage": "none — 0 grep hits for the stock model IDs in tests/; assertion bias is leave-it-alone against EMPTY or USER-CUSTOM baselines.",
+    "verificationCommand": "grep -rn 'claude-sonnet-4-20250514\\|claude-3-7-sonnet' tests/ (0 hits)",
+    "evidenceStrength": "none",
+    "riskIfFalse": "318 tests stay green while the headline first-run path ships broken — exactly what happened.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "route_task selects a model per task from complexity and falls back when a backend is not installed (pure-function model routing)",
+    "source": "prd_taskmaster/fleet.py route_task/available_backends; tests/core/test_model_routing.py",
+    "expectedBehavior": "Given cfg+avail dicts, route_task maps complexityScore/phaseConfig to the right tier model and falls back to claude when the routed backend is absent.",
+    "existingCoverage": "tests/core/test_model_routing.py:9-93 (9 tests, real return-value assertions on synthetic cfg/avail).",
+    "verificationCommand": "python3 -m pytest tests/core/test_model_routing.py -q",
+    "evidenceStrength": "strong",
+    "riskIfFalse": "Mis-routing would degrade cost/quality, but these tests genuinely assert observable routing decisions and would fail on a regression. NOTE: this module never touches credential usability — it is NOT relevant to P0/P1/P2-1 and its strength must not be read as covering the first-run bug.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  },
+  {
+    "claim": "NativeBackend (no-key) returns agent_action_required instead of silently failing",
+    "source": "prd_taskmaster/backend.py NativeBackend; tests/core/test_native_backend.py:298",
+    "expectedBehavior": "With discover_key()==None, parse/expand/rate return ok=False + agent_action_required payloads.",
+    "existingCoverage": "tests/core/test_native_backend.py:298-323 (real assertions on the agent-action contract).",
+    "verificationCommand": "python3 -m pytest tests/core/test_native_backend.py -q",
+    "evidenceStrength": "partial",
+    "riskIfFalse": "The NATIVE backend's no-key path is genuinely covered, but the SHIPPED first-run path is the TaskMaster-CLI backend (tm_parallel), which has NO equivalent research-failure test. This coverage gives false comfort: it tests a different code path than the one that broke.",
+    "verificationStatus": "passed",
+    "lastVerifiedAt": "2026-06-14T00:00:00+00:00"
+  }
+]

--- a/docs/audit/defect-register.json
+++ b/docs/audit/defect-register.json
@@ -1,0 +1,200 @@
+[
+  {
+    "id": "P0-1",
+    "dimension": "provider-config",
+    "severity": "P0",
+    "status": "confirmed",
+    "title": "configure-providers is a no-op on TaskMaster's stock paid defaults — never migrates keyless anthropic->claude-code or paid-perplexity->free proxy; first run produces 0 tasks (merges 5 finder reports)",
+    "evidence": "providers.py:55 _role_empty returns False for any non-empty dict; every model-role write gated on it at :176/:190/:207. Live repro at HEAD d506b93 with stock config, ANTHROPIC/PERPLEXITY keys unset, claude+codex on PATH, proxy up: changed=['.env:OPENAI_COMPATIBLE_API_KEY','.env:PERPLEXITY_API_BASE_URL']; main/research/fallback ALL unchanged. End-to-end parse-prd then returns ok:false/task_count:0, tasks.json never created. setup/SKILL.md:126 SKIP row + 0 grep hits for configure-providers in the skill. Smoking gun: emptying roles first makes configure correctly pick claude-code+codex-cli.",
+    "fix": "Make configure REPAIR not fill: add a KNOWN_STOCK_TASKMASTER_DEFAULTS set, treat those roles as correctable when their provider is unusable in-env, resolve desired usable provider first then apply tier on top; preserve only genuinely user-customized providers. Make setup Step 3 always run configure-providers and reword DETECT-FIRST table so unreachable!=SKIP."
+  },
+  {
+    "id": "P0-2",
+    "dimension": "provider-config",
+    "severity": "P0",
+    "status": "confirmed",
+    "title": "SETUP gate validate_setup reports ready=True for the exact 0-task config — checks model-id string presence, never credential usability",
+    "evidence": "mode_recommend.py:459 provider_ok=bool(main_model); :480 bool(research_model); zero credential/env checks in the module. Live repro on stock paid config with ANTHROPIC_API_KEY unset: ready=True, critical_failures=0. pipeline.py:90-93 gates the SETUP transition on ready+0 critical, so the gate approves the config that yields 0 tasks.",
+    "fix": "Add credential-usability checks: anthropic/perplexity require a key (else critical fail with fix string), claude-code/codex-cli require the CLI on PATH, perplexity warns+suggests free proxy when 8765 reachable. Verify provider reachability, not string presence."
+  },
+  {
+    "id": "P0-3",
+    "dimension": "parse-parallel-expand",
+    "severity": "P0",
+    "status": "confirmed",
+    "title": "expand hard-fails to 0 subtasks when research provider is out of quota — never degrades to structural expand (the dogfood failure)",
+    "evidence": "tm_parallel.py:335 hardcodes argv [binary,expand,--id,N,--research,--force]; retry _run_packet:359-409 only escalates tier, re-runs same --research command; no no-research attempt anywhere. backend.py:724 routes >3 tasks here; serial <=3 path also no structural retry; NativeBackend._expand_packet:502-510 only escalates invalid_json. Live repro (fake task-master failing iff --research): ok=False, failed=[1,2,3,4,5], subtasks [0,0,0,0,0]; structural expand never attempted. Contradicts generate/SKILL.md:276-277 'always available' structural fallback.",
+    "fix": "On research-provider failure (kind in rate_limit/quota/auth/no_key or non-zero exit), retry the SAME expansion WITHOUT --research before failing; add to tm_parallel._run_one_attempt and NativeBackend._expand_packet; surface degraded=True."
+  },
+  {
+    "id": "P1-1",
+    "dimension": "parse-parallel-expand",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "parse-prd reports ok=true/task_count=0 (CLI exits 0) when the model produced zero tasks",
+    "evidence": "backend.py:718-722 returns {ok:True,task_count:len(tasks)} on returncode==0 with no len>0 guard; cli.py:87-89 exits 0 when ok truthy. Live repro: fake parse-prd warns to stderr, exits 0 -> ok:true,task_count:0,EXIT 0. Only downstream defense is GENERATE gate (pipeline.py:100-101) which generate/SKILL.md:39-44 tells the agent to bypass on first entry.",
+    "fix": "Treat len(tasks)==0 on returncode==0 as ok=False with explanatory error; mirror in NativeBackend.parse_prd; stop documenting the GENERATE gate bypass."
+  },
+  {
+    "id": "P1-2",
+    "dimension": "provider-config",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "research_choice 'real_api_if_key' (balanced default) selects paid Perplexity on key PRESENCE over the available free local proxy, never validating the key (merges 3 finder reports)",
+    "evidence": "providers.py:209-216: paid-perplexity branch (:211-212) evaluated before elif local_proxy_available (:215); _has_perplexity_api_key (:125-129) presence-only. Repro: empty research role + PERPLEXITY_API_KEY=junk + proxy up -> research=perplexity/sonar (paid); key unset -> free openai-compatible proxy. Latent behind P0-1 (only fires on empty research role).",
+    "fix": "When free proxy answers a real 200 probe, prefer it unless user explicitly opted into paid AND the key passes a validity probe; fall back to proxy on auth/quota failure."
+  },
+  {
+    "id": "P1-3",
+    "dimension": "provider-config",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "Zero provider credential validity/health check before writing config or before parse — presence is the only signal",
+    "evidence": "has_anthropic_key (providers.py:171) and _has_perplexity_api_key (:125) pure presence; local-proxy availability (:202-206) trusts URL substring OR bare TCP-open (lib.py:259, no HTTP 200); backend.py:701-722 shells with no pre-flight, returns task_count:0+stderr on failure. Out-of-quota keys (the dogfood reality) undetectable.",
+    "fix": "Add a shared health probe used by configure (pre-write) and SETUP gate (pre-parse): which+--version for CLIs, real HTTP 200 for proxy, key-format sanity (optional auth ping) for paid APIs."
+  },
+  {
+    "id": "P1-4",
+    "dimension": "provider-config",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "Tier-migration branch keeps the unusable provider and only swaps modelId — makes a keyless anthropic config differently-broken, not fixed",
+    "evidence": "providers.py:180-187 -> _main_model_for_start_tier (:114-122) rewrites only modelId, provider preserved. Repro under conservative: keyless claude-sonnet-4 -> keyless claude-haiku-4-5 (still anthropic, still no key); under balanced the branch never fires. One finder downgraded to P2 (branch gated behind non-default conservative economy, resulting state equivalently-broken not worse).",
+    "fix": "Fold into P0-1 repair: provider decision must precede and dominate tier decision; apply tier on top of a usable provider."
+  },
+  {
+    "id": "P1-5",
+    "dimension": "skills-mcp",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "Skills reference unregistered MCP tools: tm_parse_prd, tm_analyze_complexity, update_pipeline_task_status",
+    "evidence": "generate/SKILL.md:211 tm_parse_prd, :225 tm_analyze_complexity, execute-task/SKILL.md:207 update_pipeline_task_status — none in server.py's 33 registered tools (correct: parse_prd, rate_tasks, set_task_status). One finder downgraded to P2 (labeled fallback beneath working CLI primary paths; FastMCP returns loud not-found, not silent corruption).",
+    "fix": "Rename in skills to the registered names, or add thin alias tools in server.py."
+  },
+  {
+    "id": "P1-6",
+    "dimension": "skills-mcp",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "execute-task Step 10c pipeline-consistency write broken on BOTH branches (missing MCP tool + wrong module path + unread key)",
+    "evidence": "Primary calls unregistered mcp__plugin_prd_go__update_pipeline_task_status (execute-task/SKILL.md:207); fallback references mcp-server/pipeline.py:locked_update() which does not exist (real: prd_taskmaster/pipeline.py; locked_update at prd_taskmaster/lib.py:78); fallback writes phase_evidence.EXECUTE.tasks_completed key no code reads. pipeline.json silently drifts from tasks.json.",
+    "fix": "Add update_pipeline_task_status(task_id,status) tool delegating to prd_taskmaster/pipeline.py, or rewrite Step 10c onto advance_phase/log_progress and fix the module path."
+  },
+  {
+    "id": "P1-7",
+    "dimension": "parse-parallel-expand",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "Concurrent apply_results/write_atomic on tasks.json loses updates AND crashes (FileNotFoundError) — single-writer claim false",
+    "evidence": "parallel.py:84 fixed tmp name path.with_suffix('.json.tmp') (not pid-unique); apply_results :125-182 unlocked read-modify-write. Correct primitives unused (lib.py:73 atomic_write pid-suffix, lib.py:78 locked_update flock). 60-run two-thread repro: 9 lost-update, 48 FileNotFoundError. CLI exposes apply/inject. One finder downgraded to P3 (no shipped path calls apply_results concurrently).",
+    "fix": "Route write through lib.atomic_write and RMW through lib.locked_update(parallel.TASKS, transform); same for cmd_inject; correct the docstring. Land with the cluster; do not let it block on its own."
+  },
+  {
+    "id": "P1-8",
+    "dimension": "dogfood-replay",
+    "severity": "P1",
+    "status": "confirmed",
+    "title": "configure-providers falsely reports local_perplexity_api_free:true while research still points at paid Perplexity",
+    "evidence": "providers.py:250-251 emits local_perplexity_api_free from local_proxy_available (:202-206, mere reachability), decoupled from whether research role was set to proxy. Repro on stock config: local_perplexity_api_free:true alongside unchanged research=perplexity/sonar. One finder downgraded to P2 (diagnostic-only field, no programmatic reader; cited .env-write doesn't fire on a clean config).",
+    "fix": "Report true only when models['research'] is actually the local proxy (check the role dict's own baseURL, not the env-var fallback)."
+  },
+  {
+    "id": "P2-1",
+    "dimension": "parse-parallel-expand",
+    "severity": "P2",
+    "status": "confirmed",
+    "title": "expand --no-research and --id silently ignored when >3 tasks pending",
+    "evidence": "backend.py:724-731 calls tm_parallel.run_tm_parallel(tag=tag) dropping research and task_ids; serial <=3 path honors them (backend.py:744-746). A fresh viral PRD usually yields >3 tasks so first run takes the parallel path that hardcodes --research, removing the escape hatch when P0-3 bites.",
+    "fix": "Thread research down to _run_one_attempt's argv and add task selection to run_tm_plan; note run_tm_parallel's signature currently accepts neither, so full plumbing is required."
+  },
+  {
+    "id": "P2-2",
+    "dimension": "security-packaging",
+    "severity": "P2",
+    "status": "confirmed",
+    "title": "package.json postinstall silently pip-installs into the user's active Python env; fails silently on PEP-668 distros",
+    "evidence": "package.json:26 'pip install -r mcp-server/requirements.txt 2>/dev/null || echo WARN'. Reproduced externally-managed-environment failure on this box (EXTERNALLY-MANAGED marker present), swallowed by 2>/dev/null; MCP server then cannot import mcp/fastmcp (server.py:22).",
+    "fix": "Don't auto-pip in postinstall; print exact venv/pipx command, detect PEP-668, drop 2>/dev/null so failure is visible."
+  },
+  {
+    "id": "P2-3",
+    "dimension": "security-packaging",
+    "severity": "P2",
+    "status": "confirmed",
+    "title": "Engine writes .env but never adds .env/.taskmaster/ to .gitignore — secret hygiene inherited from task-master init",
+    "evidence": "providers.py:223-241 writes .env; zero .gitignore writers in engine. Live repro: empty hand-rolled .gitignore -> git check-ignore .env non-zero, git status shows ?? .env and ?? .taskmaster/. task-master init's .gitignore covers .env but not .taskmaster/.",
+    "fix": "Idempotently ensure .env and .taskmaster/ are in .gitignore whenever the engine writes them (same append-if-missing pattern as _ensure_env_entry)."
+  },
+  {
+    "id": "P2-4",
+    "dimension": "dogfood-replay",
+    "severity": "P2",
+    "status": "confirmed",
+    "title": "Local proxy research role incompatible with task-master --research parse path (envelope shape mismatch)",
+    "evidence": "Proxy returns bare {tasks:[...]} body; task-master openai-compatible adapter expects {choices:[{message:{content}}]} -> AI_TypeValidationError path ['choices']. Degraded-not-fatal (falls through); default parse-prd doesn't pass --research but expand/rate (backend.py:746, tm_parallel.py:335) do.",
+    "fix": "Have the proxy emit a proper OpenAI chat-completions envelope (durable), or guard expand/rate away from the proxy and document main-only safety."
+  },
+  {
+    "id": "P2-5",
+    "dimension": "cli",
+    "severity": "P2",
+    "status": "confirmed",
+    "title": "handoff skill calls script.py append-workflow/debrief/handoff-gate — none exist as CLI subcommands",
+    "evidence": "cli.py DISPATCH has none; verified 'invalid choice'. Exist only as MCP tools (server.py:269,302); handoff-gate exists nowhere ('(when implemented)' in handoff/SKILL.md:341). MCP-mode works; documented CLI fallback dead.",
+    "fix": "Add append-workflow/debrief CLI subcommands as thin wrappers, or relabel as MCP-only with a real inline fallback; implement or remove handoff-gate."
+  },
+  {
+    "id": "P2-6",
+    "dimension": "tests",
+    "severity": "P2",
+    "status": "confirmed",
+    "title": "Test suite has no coverage for stock-default correction; encodes leave-it-alone as desired",
+    "evidence": "test_dogfood_fixes.py:174-189 asserts a populated role is not touched; no test seeds the stock anthropic/perplexity/anthropic trio keyless and asserts correction (0 grep hits). One finder corrected the exact-branch claim (stock anthropic IS in KNOWN_ENGINE_DEFAULTS) but the residual coverage gap is real. 318 collected, all green while the bug shipped.",
+    "fix": "Add the 6 regression tests in Section 5; update test_configure_providers_user_configured_main_is_not_touched to seed a key-bearing provider."
+  },
+  {
+    "id": "P3-1",
+    "dimension": "security",
+    "severity": "P3",
+    "status": "downgraded",
+    "title": "SHIP_CHECK_OK Gate-5 override is a hardcoded plaintext constant",
+    "evidence": "skel/ship-check.py:57 OVERRIDE_TOKEN='SHIP_CHECK_OVERRIDE_ADMIN' (also packaged shipcheck.py:57). Repro: --override SHIP_CHECK_OVERRIDE_ADMIN bypasses failing Gate 5 (prints SHIP_CHECK_OK [OVERRIDE], exit 0). Gates themselves unfakable; override audit-logged + marked, never auto-supplied (not reachable on first run); README never claims token is secret.",
+    "fix": "Optional: move override behind an env-set secret/nonce; keep the [OVERRIDE] marker + audit log; clarify wording."
+  },
+  {
+    "id": "P3-2",
+    "dimension": "packaging",
+    "severity": "P3",
+    "status": "confirmed",
+    "title": "package.json missing author/bugs/homepage — degraded npm registry page",
+    "evidence": "Confirmed at 5.2.0: author=None, bugs=None, homepage=None. .claude-plugin/plugin.json already has author{Atlas AI} + homepage. npm page (where 509 stars land) shows no author byline, no Report-issues link.",
+    "fix": "Add author/homepage/bugs to package.json mirroring plugin.json."
+  },
+  {
+    "id": "P3-3",
+    "dimension": "security",
+    "severity": "P3",
+    "status": "confirmed",
+    "title": "install.sh --with-taskmaster runs global npm install -g task-master-ai (interactive default YES)",
+    "evidence": "install.sh:94 npm install -g task-master-ai; prompt defaults YES (case ${answer:-Y}, :120); curl|bash skips via ! -t 0 guard (:111). Bounded, gated, reversible. Title's 'pip side-effects' unsupported (no pip in install.sh).",
+    "fix": "Default the prompt to N; surface that it's a global install that may need elevated perms."
+  },
+  {
+    "id": "P3-4",
+    "dimension": "skills-mcp",
+    "severity": "P3",
+    "status": "downgraded",
+    "title": "MCP prefix mcp__plugin_prd_go__ hardcoded in skills/hooks — verified correct, latent only",
+    "evidence": ".claude-plugin/plugin.json name=prd, .mcp.json server=go; commit 9c44027 establishes Claude Code generates mcp__plugin_<name>_<server>__<tool>, so mcp__plugin_prd_go__ is correct. Mitigated by ToolSearch discovery preferring mcp__atlas-engine__ (live server).",
+    "fix": "Re-verify against a clean /plugin install prd in-session; keep ToolSearch as runtime authority; label hardcoded prefixes as aliases."
+  },
+  {
+    "id": "P3-5",
+    "dimension": "dogfood-replay",
+    "severity": "P3",
+    "status": "downgraded",
+    "title": "parse-prd failure stderr passthrough — PRD-leak vector is inert in the named path",
+    "evidence": "backend.py:713 returns result.stderr; but the full-PRD/request-body dump goes to STDOUT (task-master [ERROR] line), which parse_prd's error dict (backend.py:709-714) discards. Actual stderr is a clean ~935-byte quota message. The real leak vector is the expand stdout path (backend.py:764), never reached in the dogfood replay (parse failed first).",
+    "fix": "Optional: redact multi-KB request/response bodies in the expand stdout passthrough; the parse_prd stderr fix would be a no-op."
+  }
+]

--- a/docs/audit/recommended-test-tasks.md
+++ b/docs/audit/recommended-test-tasks.md
@@ -1,0 +1,147 @@
+# Recommended Test Tasks — must go GREEN (and prove RED) before viral relaunch
+
+Prioritized by `riskIfFalse × current evidence weakness`. Each task names the claim it protects,
+the exact test to add/fix, the assertions, why current coverage is insufficient, and the command
+that verifies it. Several existing tests must be FIXED, not just added — they currently lock the bug.
+
+The prior audit (`defect-register.json` P2-6) named 6 regression tests. They are validated and
+extended below as T1-T8 (T1-T6 ≈ the original six; T7-T8 added: the anti-regression-lock fix and the
+parallel-path argument-drop guard, which the original list under-specified).
+
+---
+
+## P0 — these block relaunch
+
+### T1 — configure-providers CORRECTS a keyless anthropic stock default (protects C1 / P0-1)
+- **Add** `tests/core/test_dogfood_fixes.py::test_configure_providers_corrects_keyless_stock_anthropic_to_cli`
+- **Setup:** seed `.taskmaster/config.json` with the real `task-master init` trio:
+  `main=anthropic/claude-sonnet-4-20250514`, `research=perplexity/sonar`,
+  `fallback=anthropic/claude-3-7-sonnet-20250219`; `ANTHROPIC_API_KEY` and `PERPLEXITY_API_KEY`
+  unset; patch `providers.shutil.which` so `claude` and `codex` resolve.
+- **Assert:** `result["models"]["main"]["provider"] == "claude-code"` (NOT anthropic);
+  `"main" in result["changed"]`; research migrated off paid perplexity to the local proxy or a
+  usable provider.
+- **Why current coverage fails:** test_dogfood_fixes.py:113/140/157/174/215 only seed EMPTY `{}` or
+  user-custom `openai` roles; 0 tests construct the keyless stock trio
+  (`grep -rn 'claude-sonnet-4-20250514' tests/` -> 0 hits). `_role_empty` (providers.py:55) skips all
+  rewrites on a populated config, so this is the no-op that ships.
+- **Red/green:** RED against current providers.py (main stays anthropic); GREEN after the P0-1
+  repair (KNOWN_STOCK_TASKMASTER_DEFAULTS + provider-decision-before-tier).
+- **Verify:** `python3 -m pytest tests/core/test_dogfood_fixes.py -k corrects_keyless_stock -q`
+
+### T2 — configure-providers with NO usable provider surfaces a critical error (protects C1 / P0-1)
+- **Add** `..._configure_providers_no_usable_provider_fails_loudly`
+- **Setup:** keyless stock trio; `shutil.which` -> None for claude AND codex; local proxy not
+  reachable.
+- **Assert:** result signals an unrecoverable setup (e.g. raises CommandError or returns a critical
+  flag) rather than silently leaving paid keyless defaults; `changed` does not falsely imply success.
+- **Why:** today this exact case returns `changed=['.env:...']` only and leaves a 0-task config that
+  the gate then approves (live-reproduced).
+- **Verify:** `python3 -m pytest tests/core/test_dogfood_fixes.py -k no_usable_provider -q`
+
+### T3 — validate_setup reports ready=False for a keyless anthropic config (protects C2 / P0-2)
+- **Add** `tests/core/test_capabilities.py::TestValidateSetup::test_validate_setup_not_ready_when_anthropic_keyless`
+- **Setup:** fake task-master on PATH (so binary/version pass); `.taskmaster/config.json` with the
+  REAL shape `main={"provider":"anthropic","modelId":"claude-sonnet-4-20250514",...}`;
+  `ANTHROPIC_API_KEY` unset.
+- **Assert:** `result["ready"] is False`; `result["critical_failures"] >= 1`; the failing check
+  names the missing ANTHROPIC_API_KEY with a fix hint.
+- **Why current coverage fails:** `test_validate_setup_passes_with_full_project` (:203) uses a
+  fixture with NO `provider` field and asserts ready=True — proven this session to still pass even
+  after a correct provider-keyed credential fix (degenerate fixture).
+- **Red/green:** RED against current mode_recommend.py (ready=True, live-reproduced);
+  GREEN after the P0-2 credential-usability checks land.
+- **Verify:** `python3 -m pytest 'tests/core/test_capabilities.py::TestValidateSetup' -q`
+
+### T4 — FIX the existing validate_setup happy-path fixture to use a real, credentialed config (protects C2 / P0-2)
+- **Fix** `test_validate_setup_passes_with_full_project` (test_capabilities.py:203):
+  add `provider: "claude-code"` to `main` (a CLI provider needing no key) OR set `ANTHROPIC_API_KEY`
+  and use `provider: "anthropic"`. The fixture must represent a config that can *actually* produce
+  tasks, so ready=True is earned, not asserted on a shape that never occurs.
+- **Why:** without this fix, T3 and the P0-2 code change can both be correct while this test stays
+  green for the wrong reason — a permanent false-green.
+- **Verify:** `python3 -m pytest 'tests/core/test_capabilities.py::TestValidateSetup::test_validate_setup_passes_with_full_project' -q`
+
+### T5 — expand degrades to STRUCTURAL (no --research) on a research-only failure (protects C3 / P0-3)
+- **Add** `tests/core/test_tm_parallel.py::test_expand_falls_back_to_structural_when_research_fails`
+- **Setup:** extend the fake task-master (test_tm_parallel.py:15) with a new mode, e.g. `research_fail`,
+  that exits non-zero **iff** `--research` is in argv and exits 0 (writing 2 subtasks) when `--research`
+  is absent. Seed >0 pending tasks.
+- **Assert:** the run ultimately succeeds with subtasks > 0; a no-`--research` `expand` was actually
+  executed (inspect the logged argv); result surfaces `degraded=True`.
+- **Why current coverage fails:** test_tm_run_failure_retries (:184) uses `mode='fail'` which fails on
+  ALL expands regardless of `--research`, so it asserts `failed==[1]` and codifies that the retry
+  re-runs `--research`. tm_parallel.py:335 hardcodes `--research` with no structural attempt.
+- **Red/green:** RED against current tm_parallel.py (structural never attempted -> still fails);
+  GREEN after the P0-3 fix adds a no-research retry on rate_limit/quota/auth/no_key.
+- **Verify:** `python3 -m pytest tests/core/test_tm_parallel.py -k structural -q`
+
+### T6 — serial expand also degrades to structural on research failure (protects C3 / P0-3)
+- **Add** `tests/core/test_backend.py::test_serial_expand_retries_without_research_on_research_failure`
+- **Setup:** <=3 pending tasks; fake task-master that fails the `--research` expand and succeeds the
+  plain `expand`.
+- **Assert:** `result["ok"] is True`; the logged commands include a no-`--research` retry for the
+  failed task; `degraded` surfaced.
+- **Why:** backend.py:744-746 serial branch appends `--research` and never retries structurally.
+- **Verify:** `python3 -m pytest tests/core/test_backend.py -k retries_without_research -q`
+
+### T7 — FIX the anti-regression lock so the P0-3 structural fix is not blocked (protects C3 / P0-3) — CRITICAL
+- **Fix** `test_expand_serial_branch_runs_binary_and_appends_telemetry` (test_backend.py:180-204).
+  Today it hard-asserts `commands == [[expand,--id,N,--research]...]`. Mutation-proven this session:
+  dropping `--research` turns it RED, so it will block the correct fix at review.
+- **Change:** assert the *initial* attempt uses `--research` (the happy path) but stop pinning it as
+  the *only* command. Replace the exact-list equality with: each task got at least one `--research`
+  attempt; allow (do not forbid) a subsequent structural attempt. Or split into a happy-path test
+  (research succeeds -> only --research) and let T6 own the failure path.
+- **Why:** a passing test that enforces the bug is worse than no test; this is the single most likely
+  reason a correct fix gets reverted in review.
+- **Verify:** `python3 -m pytest tests/core/test_backend.py -k serial_branch -q` (must still pass on
+  the happy path AND not fail when a structural fallback exists)
+
+---
+
+## P1 — land with the P0 cluster
+
+### T8 — the >3-pending parallel path threads research/task_ids through (protects C7 / P2-1)
+- **Fix/extend** `test_expand_delegates_to_tm_parallel_for_more_than_three_pending` (test_backend.py:160).
+  Call `expand(task_ids=[2], research=False, tag="master")` with >3 pending and **assert
+  `called.get("research") is False` and `called.get("task_ids") == [2]`** (after backend.py:727 is
+  fixed to pass them).
+- **Why:** today it asserts only `called["tag"]`; the test passes while research/task_ids are dropped.
+- **Red/green:** RED until backend.py:727 forwards the args and run_tm_parallel accepts them.
+- **Verify:** `python3 -m pytest tests/core/test_backend.py -k delegates_to_tm_parallel -q`
+
+### T9 — parse-prd returns ok=False on returncode==0 with zero tasks (protects C4 / P1-1)
+- **Add** `tests/core/test_backend.py::test_parse_prd_zero_tasks_is_failure`
+- **Setup:** fake task-master `parse-prd` that exits 0 but writes `{tag:{tasks:[]}}` (warn-to-stderr,
+  zero tasks — the real model-produced-nothing case).
+- **Assert:** `result["ok"] is False`; explanatory `error`; CLI wrapper exits non-zero.
+- **Why:** backend.py:719 returns ok=True for any returncode==0; no test seeds 0 tasks.
+- **Verify:** `python3 -m pytest tests/core/test_backend.py -k zero_tasks -q`
+
+### T10 — research selection prefers the free proxy over an INVALID paid key (protects C5 / P1-2)
+- **Add** `..._configure_providers_prefers_proxy_when_perplexity_key_invalid`
+- **Setup:** empty research role; `PERPLEXITY_API_KEY="junk"`; proxy reachable; a stubbed validity
+  probe that reports the key invalid.
+- **Assert:** `result["models"]["research"]["provider"] == "openai-compatible"` (proxy), not paid
+  perplexity.
+- **Why:** providers.py:211-216 prefers paid on key *presence*; test_dogfood_fixes.py:140/157 assert
+  the presence-only behavior is correct.
+- **Verify:** `python3 -m pytest tests/core/test_dogfood_fixes.py -k prefers_proxy -q`
+
+---
+
+## Definition of done for relaunch
+
+Run all new/fixed tests and the full suite:
+
+```
+python3 -m pytest tests/core/test_dogfood_fixes.py tests/core/test_capabilities.py \
+  tests/core/test_backend.py tests/core/test_tm_parallel.py -q
+python3 -m pytest tests/ -q          # full suite must stay green WITH the fixes
+```
+
+Acceptance gate: T1-T7 must each demonstrate RED on current `main` and GREEN after the corresponding
+P0 fix (T4 and T7 are fixture/lock corrections that must pass *with* the fix and *not* re-pin the bug).
+Until then, the contract in `TEST_CONTRACT.md` (C1/C2/C3) is NOT met and the engine can ship 0 tasks
+to a keyless first-time user with all tests green — which is the state at HEAD ~d506b93.

--- a/docs/audit/test-suite-audit.md
+++ b/docs/audit/test-suite-audit.md
@@ -1,0 +1,204 @@
+# Test-Suite Contract Audit — prd-taskmaster (Atlas) engine
+
+Audited HEAD ~d506b93, version 5.2.0, 2026-06-14. Suite executed fresh this session:
+`python3 -m pytest tests/ -q` -> **318 passed in ~40s**; `python3 -m pytest tests/core -q`
+-> **237 passed in ~17s**. Zero skips. All green.
+
+This audit answers one question: **how did a 318-test green suite ship a first-run config that
+produces 0 tasks?** It corroborates the existing `defect-register.json` (P0-1/P0-2/P0-3 etc.) and
+adds the missing piece those defects don't fully state: the tests don't merely *fail to cover* the
+bug — several of them **encode the broken behavior as the expected behavior**.
+
+---
+
+## UNCOMFORTABLE FINDINGS FIRST
+
+### F1 (P0-3) — A passing test ACTIVELY LOCKS the bug in place (worst case)
+
+`tests/core/test_backend.py:180-204` `test_expand_serial_branch_runs_binary_and_appends_telemetry`
+asserts the exact command list:
+
+```python
+assert commands == [
+    ["expand", "--id", "1", "--research"],
+    ["expand", "--id", "2", "--research"],
+    ["expand", "--id", "3", "--research"],
+]
+```
+
+P0-3's fix is to retry `expand` *without* `--research` when research is unavailable. **Red/green
+proof, executed this session:** I mutated `backend.py:744-746` to drop the `--research` append
+(simulating the structural-fallback fix) and ran just this test — it went **RED**:
+
+```
+At index 0 diff: ['expand', '--id', '1'] != ['expand', '--id', '1', '--research']
+FAILED tests/core/test_backend.py::test_expand_serial_branch_runs_binary_and_appends_telemetry
+```
+
+backend.py was then fully reverted (`git diff --stat prd_taskmaster/backend.py` clean). This is the
+worst category of test: not absent coverage, but coverage that will make a correct fix fail review.
+
+### F2 (P0-3) — The "failure retry" test can't tell research-failure from any failure
+
+`tests/core/test_tm_parallel.py:184-205` `test_tm_run_failure_retries_with_escalated_config_and_telemetry`
+looks like it tests resilience. It doesn't. The fake task-master (`tests/core/test_tm_parallel.py:15-66`)
+has modes `ok | slow | fail`; `fail` (:30-33) returns exit 1 on **any** `expand`, regardless of whether
+`--research` is present. So the test proves only that a failed expand is retried with an escalated
+*tier* — and asserts `attempts == 2` and `failed == [1]`, i.e. it **codifies that the retry re-runs
+`--research` and still fails**. There is no fake mode that fails *iff* `--research` is present, so a
+structural fallback is impossible to express, let alone require. `tm_parallel.py:335` hardcodes
+`[binary, "expand", "--id", N, "--research", "--force"]` and the retry at `_run_packet:359-409` only
+calls `shift_tier` + reruns the same `--research` command (`_run_one_attempt:331-347`).
+
+### F3 (P0-2) — The SETUP gate's "ready" test certifies a config that never occurs and can't fail
+
+`tests/core/test_capabilities.py:203-230` `test_validate_setup_passes_with_full_project` seeds:
+
+```python
+config = {"models": {"main": {"modelId": "claude-sonnet-4-5"}, ...}}   # NO provider, NO credential
+```
+
+and asserts `ready=True, critical_failures=0`. Two problems:
+1. **It asserts the bug is correct.** `mode_recommend.py:459` `provider_ok = bool(main_model)` checks
+   only that a model-id *string* is present. **Live repro this session:** `validate_setup()` against
+   the real keyless stock config (`main=anthropic/claude-sonnet-4-20250514`, `ANTHROPIC_API_KEY`
+   unset) returns `ready=True, critical_failures=0`. The gate (`pipeline.py` SETUP->DISCOVER) approves
+   the exact 0-task config.
+2. **The fixture is degenerate.** Its `main` dict has *no* `provider` key, whereas every real
+   `task-master init` config has `provider: "anthropic"`. **Mutation proof:** I applied the natural
+   P0-2 fix (`provider_ok = bool(main_model) and (provider != 'anthropic' or ANTHROPIC_API_KEY set)`)
+   and this test still **passed** — because the fixture's empty-provider config never trips the
+   anthropic branch. So even a *correct* credential check is invisible to this test. mode_recommend.py
+   reverted clean.
+
+### F4 (P0-1 / P2-6) — Assertion bias: tests only assert "leave it alone", never "correct it"
+
+The configure-providers tests in `tests/core/test_dogfood_fixes.py` exhaustively cover the
+do-nothing directions and never the repair direction:
+
+- `:113` `..._rewrites_engine_default_main_to_fast_tier` seeds `claude-code/sonnet` — a provider that
+  is **already usable** — and only checks a *tier* rewrite (sonnet->haiku). Provider migration is never
+  tested because the seed never needs migrating.
+- `:140` / `:157` seed an **EMPTY** research role (`_seed_taskmaster_config(tmp_path, {})`) and assert
+  paid sonar/sonar-pro is chosen — exercising the `_role_empty==True` branch that the real bug never
+  reaches.
+- `:174` `..._user_configured_main_is_not_touched` seeds `provider: "openai"` (a non-engine-default)
+  and asserts it is **NOT** touched. This is the leave-it-alone assertion — against a *customized*
+  baseline, never against a *keyless stock* baseline.
+- `:215` `..._free_proxy_first_preserves_local_proxy_golden` again seeds **EMPTY** `{}`.
+
+**Live repro this session:** stock keyless trio + `shutil.which` patched to None ->
+`configure-providers(balanced)` returns `changed=['.env:OPENAI_COMPATIBLE_API_KEY',
+'.env:PERPLEXITY_API_BASE_URL']` and leaves `main=anthropic/claude-sonnet-4-20250514`
+**unchanged** (`after['main'] == stock['main']` -> True). The no-op is exactly what the tests'
+absence-of-a-correction-test permits. Root cause in code: `_role_empty` (`providers.py:55`) returns
+`False` for any non-empty dict, so the writes at `:176/:190/:207` are all skipped on a pre-populated
+config. **Grep proof:** `grep -rn 'claude-sonnet-4-20250514\|claude-3-7-sonnet' tests/` -> **0 hits**;
+no test ever constructs the trio that ships.
+
+### F5 (P2-1) — The delegation test passes whether or not research/task_ids are dropped
+
+`tests/core/test_backend.py:160-178` `test_expand_delegates_to_tm_parallel_for_more_than_three_pending`
+patches `run_tm_parallel(**kwargs)` to capture kwargs, then asserts only `called["tag"] == "master"`.
+`backend.py:727` calls `tm_parallel.run_tm_parallel(tag=tag)` — silently dropping the `research` and
+`task_ids` arguments the public `expand(task_ids, research, tag)` accepts. The test never asserts those
+were threaded through, so it remains green with the drop in place. A fresh viral PRD usually yields >3
+tasks, so first run takes this parallel path and loses the `--no-research` escape hatch precisely when
+P0-3 bites.
+
+### F6 (P1-1) — parse-prd zero-task success is untested
+
+`backend.py:718-722` returns `{ok:True, task_count:len(tasks)}` on `returncode==0` with no `len>0`
+guard. `tests/core/test_backend.py:144` only tests `count=5`; `:245` only tests `returncode=1`. There
+is no test where the CLI exits 0 but wrote zero tasks (the real warn-to-stderr-exit-0 behavior), so
+`ok=True, task_count=0` is unproven and uncaught.
+
+---
+
+## Why these are mock/can't-fail tests, by category
+
+- **Anti-regression lock:** test_backend.py:180 (F1) — pins the buggy command; blocks the fix.
+- **Indistinguishable-failure mock:** test_tm_parallel.py:184 (F2) — fake fails on all expands, so
+  research-specific degradation cannot be expressed.
+- **Degenerate-fixture / can't-fail-for-the-real-shape:** test_capabilities.py:203 (F3) — fixture omits
+  the `provider` field, so a provider-keyed fix is invisible; the assertion is tautological w.r.t. the
+  bug.
+- **Assertion against the wrong baseline:** test_dogfood_fixes.py:113/140/157/174/215 (F4) — empty or
+  user-custom seeds only; the keyless-stock seed that breaks is never constructed.
+- **Captured-but-unasserted kwargs:** test_backend.py:160 (F5) — captures **kwargs, asserts one key.
+- **Untested success-with-zero:** test_backend.py:144 (F6).
+- **Right contract, wrong code path:** test_native_backend.py:204/298 — genuinely tests the NATIVE
+  backend's invalid_json escalation and no-key agent path, but the SHIPPED first-run path is the
+  TaskMaster-CLI backend (tm_parallel), which has no parallel coverage. The native coverage gives
+  false comfort.
+
+No `.skip`/`.todo`/`xit` were found in the four focus files. The disabling here is subtler than skips:
+it is *covering the wrong shape*.
+
+---
+
+## HOW the green suite shipped the broken behavior (the mechanism)
+
+1. **Two contracts were conflated.** "Config is well-formed" (a string is present, a dict has the
+   right keys) was tested; "config can actually produce tasks" (the credential/CLI/proxy works) was
+   not. validate_setup, configure-providers, and expand were all tested at the *shape* level.
+2. **The fixtures pre-decided the answer.** configure tests seed only EMPTY or USER-CUSTOM roles —
+   never the keyless paid trio that `task-master init` actually writes — so the no-op branch
+   (`_role_empty==False`) was never under test. validate_setup's fixture omits `provider` so it can't
+   trip a credential check.
+3. **One test pinned the bug as a feature.** The serial-expand command-list assertion makes
+   `--research` mandatory; the parallel-failure fake can't distinguish research failure from any
+   failure. So even an engineer writing the fix would see a test go red and assume *they* broke
+   something.
+4. **Coverage of an adjacent path masqueraded as coverage of the shipped path.** The Native backend's
+   no-key/invalid-json handling is well tested; the TaskMaster-CLI parallel path that strangers
+   actually hit is not. "expand is tested" was true for the wrong expand.
+
+Net: 318 green tests, each individually defensible, collectively certifying a product that returns 0
+tasks to a keyless first-time user.
+
+---
+
+## STRENGTHS (real coverage that does work)
+
+- `tests/core/test_model_routing.py` (9 tests) — genuine return-value assertions on `route_task`;
+  would fail on a routing regression. (Strong, but unrelated to the first-run bug.)
+- `tests/core/test_native_backend.py:183` `test_parse_prd_invalid_candidate_returns_error_without_overwrite`
+  — asserts ok=False AND that the prior tasks.json is byte-for-byte preserved; a real
+  negative-path + no-clobber assertion.
+- `tests/core/test_ship_check.py` (8 tests) — per prior audit, real subprocess tests asserting exact
+  stdout/returncode (the unfakable-gate claim).
+- `tests/core/test_tm_parallel.py` correctly tests dependency-stripping, isolation, version-gate,
+  timeout-retain, and workdir cleanup — the parallelism *mechanics* are well covered. The gap is
+  purely the research-degradation semantics.
+
+---
+
+## METHODOLOGY & WHAT WAS NOT AUDITED
+
+- Scope: the P0/P1 first-run claims and the four named test files (test_dogfood_fixes,
+  test_native_backend, test_taskmaster_wrapper, test_model_routing), plus the source they guard
+  (providers.py, mode_recommend.py, tm_parallel.py, backend.py) and the directly adjacent
+  test_backend.py / test_capabilities.py.
+- Executed: full suite (318) and core (237); two live repros of the shipped code against the exact
+  broken config; two non-destructive red/green mutations (backend.py F1 -> RED then reverted;
+  mode_recommend.py F3 -> still GREEN, demonstrating fixture degeneracy, then reverted). Working tree
+  confirmed clean of source mutations (`git diff --stat` empty; only pre-existing untracked AUDIT.md
+  and defect-register.json remain).
+- NOT audited fresh: tests/mcp (MCP tool integration), tests/plugin (hooks), tests/integration; the
+  install.sh / npm postinstall path; the local Perplexity proxy envelope mismatch (P2-4) end-to-end.
+  These are covered in the existing defect-register but not re-executed here.
+
+## RESIDUAL RISK
+
+- **P0-1, P0-2, P0-3 remain unproven by the suite** and P0-3 is anti-regression-locked. The product
+  can ship 0 tasks on a keyless first run with all 318 tests green — this is reproduced, not
+  hypothesized.
+- A correct P0-2 fix may pass the existing validate_setup test for the wrong reason (degenerate
+  fixture) — fixing the code without fixing the fixture leaves a false-green.
+- A correct P0-3 fix will FAIL test_backend.py:180 until that test is rewritten; reviewers must not
+  "restore" the `--research` assertion.
+- The Native vs TaskMaster-CLI backend split means passing native tests do not bound CLI-path
+  behavior; the shipped path's research-degradation is untested in either direction.
+- Anything in tests/mcp, tests/plugin, tests/integration is taken on its prior-audit word, not
+  re-executed here.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,15 @@
 {
   "name": "prd-taskmaster",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Zero-config goal-to-tasks engine for Claude Code (the Atlas engine)",
+  "author": {
+    "name": "Atlas AI",
+    "url": "https://atlas-ai.au"
+  },
+  "homepage": "https://github.com/anombyte93/prd-taskmaster#readme",
+  "bugs": {
+    "url": "https://github.com/anombyte93/prd-taskmaster/issues"
+  },
   "keywords": [
     "claude-code",
     "taskmaster",

--- a/prd_taskmaster/backend.py
+++ b/prd_taskmaster/backend.py
@@ -716,6 +716,22 @@ class TaskMasterBackend(Backend):
             d.setdefault("ai", "taskmaster-cli")
             return d
         _resolved, tasks = _load_tasks(tag)
+        if not tasks:
+            # P1-1: a 0-exit parse that produced no tasks is NOT success — it is the
+            # silent failure that lets the pipeline treat an empty graph as "done".
+            d = {
+                "ok": False,
+                "task_count": 0,
+                "exit": result.returncode,
+                "error": (
+                    "parse-prd exited 0 but produced 0 tasks — the model returned no "
+                    "tasks. Check provider credentials (run: python3 script.py "
+                    "configure-providers) and the PRD content."
+                ),
+            }
+            d.setdefault("backend", "taskmaster")
+            d.setdefault("ai", "taskmaster-cli")
+            return d
         d = {"ok": True, "task_count": len(tasks)}
         d.setdefault("backend", "taskmaster")
         d.setdefault("ai", "taskmaster-cli")
@@ -739,6 +755,7 @@ class TaskMasterBackend(Backend):
         results = []
         expanded = []
         failed = []
+        any_degraded = False
         for task in pending:
             task_id = task.get("id")
             cmd = [binary, "expand", "--id", str(task_id)]
@@ -747,6 +764,20 @@ class TaskMasterBackend(Backend):
             start = time.monotonic()
             result = subprocess.run(cmd, capture_output=True, text=True)
             wall_ms = int((time.monotonic() - start) * 1000)
+            degraded = False
+            if result.returncode != 0 and research:
+                # P0-3: research provider down (quota/auth). Degrade to a structural
+                # expand (no --research) — always available, still verifiable —
+                # rather than hard-failing this task to 0 subtasks.
+                s_start = time.monotonic()
+                result = subprocess.run(
+                    [binary, "expand", "--id", str(task_id)],
+                    capture_output=True,
+                    text=True,
+                )
+                wall_ms += int((time.monotonic() - s_start) * 1000)
+                degraded = True
+                any_degraded = True
             append_telemetry({
                 "ts": now_iso(),
                 "op_class": "structured_gen",
@@ -756,6 +787,7 @@ class TaskMasterBackend(Backend):
                 "exit": result.returncode,
                 "wall_ms": wall_ms,
                 "escalated": False,
+                "degraded": degraded,
             })
             item = {
                 "task_id": task_id,
@@ -763,6 +795,7 @@ class TaskMasterBackend(Backend):
                 "wall_ms": wall_ms,
                 "stdout": result.stdout,
                 "stderr": result.stderr,
+                "degraded": degraded,
             }
             results.append(item)
             if result.returncode == 0:
@@ -776,6 +809,8 @@ class TaskMasterBackend(Backend):
             "failed": failed,
             "results": results,
         }
+        if any_degraded:
+            d["degraded"] = True
         d.setdefault("backend", "taskmaster")
         d.setdefault("ai", "taskmaster-cli")
         return d

--- a/prd_taskmaster/mode_recommend.py
+++ b/prd_taskmaster/mode_recommend.py
@@ -16,7 +16,13 @@ from pathlib import Path
 from typing import Any
 
 from prd_taskmaster.lib import emit_json_error
-from prd_taskmaster.providers import _has_perplexity_api_key, _provider_usable
+from prd_taskmaster.providers import (
+    _has_perplexity_api_key,
+    _is_nested_claude,
+    _is_spawning_provider,
+    _probe_spawn,
+    _provider_usable,
+)
 
 # ---------------------------------------------------------------------------
 # Constants (mirrored from v4 script.py)
@@ -463,6 +469,7 @@ def validate_setup() -> dict:
     research_model: str | None = None
     research_provider: str | None = None
     main_usable = False
+    nested_spawn_block = False
     if has_config:
         try:
             with open(config_file) as f:
@@ -477,8 +484,22 @@ def validate_setup() -> dict:
             research_model = research.get("modelId")
             fallback_model = fallback.get("modelId")
             main_usable = _provider_usable(main_provider, **usable_kwargs)
+            # #11/#12: a CLI-spawning provider may pass the credential check (CLI on
+            # PATH) yet still be unable to spawn a child inside a nested Claude
+            # session. PROBE it — don't assume either way.
+            nested_spawn_block = False
+            if main_usable and _is_spawning_provider(main_provider) and _is_nested_claude():
+                if not _probe_spawn(main_provider):
+                    main_usable = False
+                    nested_spawn_block = True
             provider_ok = bool(main_model) and main_usable
-            if bool(main_model) and not main_usable:
+            if nested_spawn_block:
+                provider_detail = (
+                    f"main={main_provider}/{main_model}: the '{main_provider}' CLI cannot spawn a "
+                    "child inside this nested Claude Code session — parse/expand would die with "
+                    "exit 1 and write no tasks"
+                )
+            elif bool(main_model) and not main_usable:
                 provider_detail = (
                     f"main={main_provider or '?'}/{main_model} configured, but provider "
                     f"'{main_provider}' has no usable credential/CLI here — would produce 0 tasks"
@@ -499,10 +520,18 @@ def validate_setup() -> dict:
         "detail": provider_detail,
         "fix": (
             (
-                "python3 script.py configure-providers"
-                "  # migrate the unusable provider to your installed claude/codex CLI (or set its API key)"
-                if (main_model and not main_usable)
-                else "task-master models --set-main sonnet --claude-code"
+                (
+                    "Run Atlas from a plain shell (outside Claude Code), OR set ANTHROPIC_API_KEY "
+                    "to use the Anthropic API instead of the CLI spawn, OR run: "
+                    "python3 script.py configure-providers"
+                )
+                if nested_spawn_block
+                else (
+                    "python3 script.py configure-providers"
+                    "  # migrate the unusable provider to your installed claude/codex CLI (or set its API key)"
+                    if (main_model and not main_usable)
+                    else "task-master models --set-main sonnet --claude-code"
+                )
             )
             if not provider_ok else None
         ),

--- a/prd_taskmaster/mode_recommend.py
+++ b/prd_taskmaster/mode_recommend.py
@@ -9,12 +9,14 @@ All functions return dicts — never terminate the process (per spec §13.3).
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Any
 
 from prd_taskmaster.lib import emit_json_error
+from prd_taskmaster.providers import _has_perplexity_api_key, _provider_usable
 
 # ---------------------------------------------------------------------------
 # Constants (mirrored from v4 script.py)
@@ -443,48 +445,88 @@ def validate_setup() -> dict:
         "fix": "task-master init --yes" if not has_config else None,
     })
 
-    # Check 5: main model configured
+    # Check 5: main model configured AND its provider is usable here.
+    # A model-id string is not enough: a paid 'anthropic' main with no
+    # ANTHROPIC_API_KEY (TaskMaster's stock default) is configured but cannot
+    # run, and silently produces 0 tasks. The gate must verify reachability.
+    usable_kwargs = {
+        "has_claude": shutil.which("claude") is not None,
+        "has_codex": shutil.which("codex") is not None,
+        "has_anthropic_key": bool(os.environ.get("ANTHROPIC_API_KEY")),
+        "has_openai_key": bool(os.environ.get("OPENAI_API_KEY")),
+        "has_perplexity_key": _has_perplexity_api_key(),
+    }
     provider_ok = False
     provider_detail = "Cannot read config"
     main_model: str | None = None
+    main_provider: str | None = None
     research_model: str | None = None
+    research_provider: str | None = None
+    main_usable = False
     if has_config:
         try:
             with open(config_file) as f:
                 cfg = json.load(f)
             models = cfg.get("models", {})
-            main_model = models.get("main", {}).get("modelId")
-            research_model = models.get("research", {}).get("modelId")
-            fallback_model = models.get("fallback", {}).get("modelId")
-            provider_ok = bool(main_model)
-            provider_detail = (
-                f"main={main_model or 'unset'}, "
-                f"research={research_model or 'unset'}, "
-                f"fallback={fallback_model or 'unset'}"
-            )
+            main = models.get("main", {}) or {}
+            research = models.get("research", {}) or {}
+            fallback = models.get("fallback", {}) or {}
+            main_provider = main.get("provider")
+            main_model = main.get("modelId")
+            research_provider = research.get("provider")
+            research_model = research.get("modelId")
+            fallback_model = fallback.get("modelId")
+            main_usable = _provider_usable(main_provider, **usable_kwargs)
+            provider_ok = bool(main_model) and main_usable
+            if bool(main_model) and not main_usable:
+                provider_detail = (
+                    f"main={main_provider or '?'}/{main_model} configured, but provider "
+                    f"'{main_provider}' has no usable credential/CLI here — would produce 0 tasks"
+                )
+            else:
+                provider_detail = (
+                    f"main={main_provider or '?'}/{main_model or 'unset'}, "
+                    f"research={research_provider or '?'}/{research_model or 'unset'}, "
+                    f"fallback={fallback_model or 'unset'}"
+                )
         except (json.JSONDecodeError, KeyError, OSError) as exc:
             provider_detail = f"config.json unreadable: {exc}"
 
     checks.append({
         "id": "provider_main",
-        "name": "Main model configured",
+        "name": "Main model configured and reachable",
         "passed": provider_ok,
         "detail": provider_detail,
-        "fix": "task-master models --set-main sonnet --claude-code" if not provider_ok else None,
+        "fix": (
+            (
+                "python3 script.py configure-providers"
+                "  # migrate the unusable provider to your installed claude/codex CLI (or set its API key)"
+                if (main_model and not main_usable)
+                else "task-master models --set-main sonnet --claude-code"
+            )
+            if not provider_ok else None
+        ),
     })
 
-    # Check 6: research model configured (soft — not blocking)
+    # Check 6: research model configured AND reachable (soft — not blocking,
+    # because expand degrades to a structural pass when research is unavailable).
+    research_usable = bool(research_model) and _provider_usable(research_provider, **usable_kwargs)
     checks.append({
         "id": "provider_research",
-        "name": "Research model configured (optional but recommended)",
-        "passed": bool(research_model),
+        "name": "Research model configured and reachable (optional but recommended)",
+        "passed": research_usable,
         "detail": (
-            f"research={research_model}" if research_model
-            else "research model unset — expand --research will fail"
+            f"research={research_provider or '?'}/{research_model}"
+            if research_usable
+            else (
+                f"research={research_provider or '?'}/{research_model or 'unset'} not reachable — "
+                "expand will fall back to structural (no --research)"
+            )
         ),
         "fix": (
-            "task-master models --set-research opus --claude-code"
-            if not research_model else None
+            "python3 script.py configure-providers"
+            "  # points research at the free local proxy or your claude/codex CLI"
+            if not research_usable else None
         ),
         "severity": "warning",
     })

--- a/prd_taskmaster/pipeline.py
+++ b/prd_taskmaster/pipeline.py
@@ -164,6 +164,14 @@ def _current_tag(state: dict, tag_lists: dict[str, list[dict]]) -> str:
     return next(iter(tag_lists), "master")
 
 
+def _fresh_tag(existing: set[str]) -> str:
+    """Deterministic next unused parse tag, so a new PRD does not pollute a stale tag."""
+    n = 1
+    while f"prd-{n}" in existing:
+        n += 1
+    return f"prd-{n}"
+
+
 def _recommended_pending_tag(tag_counts: dict[str, dict[str, int]]) -> str | None:
     ready_tags = [
         (tag, counts)
@@ -200,6 +208,14 @@ def preflight(cwd: Optional[str] = None) -> dict:
     has_taskmaster = TASKMASTER_DIR.exists()
     alternate_pending_tag = _recommended_pending_tag(tag_counts)
 
+    # #13: a non-empty but fully-done current tag is "stale" — parsing a new PRD into
+    # it would pollute the old graph. Flag it and suggest a fresh tag (additive; does
+    # not change the recommended_action ladder).
+    current_tag_stale = bool(tasks_count > 0 and pending_count == 0)
+    suggested_fresh_tag = (
+        _fresh_tag(set(task_lists)) if (current_tag_stale and prd_exists) else None
+    )
+
     if has_taskmaster and pending_count > 0:
         rec = "resume_existing_tasks"
     elif prd_exists and tasks_count == 0:
@@ -229,6 +245,8 @@ def preflight(cwd: Optional[str] = None) -> dict:
         "tasks_path": str(TASKS_FILE) if TASKS_FILE.exists() else None,
         "current_tag": current_tag,
         "recommended_tag": recommended_tag,
+        "current_tag_stale": current_tag_stale,
+        "suggested_fresh_tag": suggested_fresh_tag,
         "tag_counts": tag_counts,
         "recommended_action": rec,
     }

--- a/prd_taskmaster/providers.py
+++ b/prd_taskmaster/providers.py
@@ -51,9 +51,57 @@ _STRUCTURED_GEN_TIER_MODELS = {
     "frontier": "fable",
 }
 
+# (provider, modelId) pairs that `task-master init` writes by default. These are
+# NOT user choices — they are stock defaults. When their provider is unusable in
+# the current environment (no key / no CLI) the engine must REPAIR them onto an
+# available free path rather than no-op (the P0-1 first-run failure). Genuine
+# user-customized providers (openai, openrouter, ollama, …) are never in this set
+# and are always preserved.
+KNOWN_STOCK_TASKMASTER_DEFAULTS = {
+    ("anthropic", "claude-sonnet-4-20250514"),
+    ("anthropic", "claude-3-7-sonnet-20250219"),
+    ("perplexity", "sonar"),
+    ("perplexity", "sonar-pro"),
+}
+
 
 def _role_empty(value: object) -> bool:
     return not isinstance(value, dict) or not value
+
+
+def _provider_usable(
+    provider: object,
+    *,
+    has_claude: bool,
+    has_codex: bool,
+    has_anthropic_key: bool,
+    has_openai_key: bool,
+    has_perplexity_key: bool,
+) -> bool:
+    """Can this provider actually run a request in the current environment?
+
+    Presence of a *credential* or *CLI* — not merely a config string. Unknown
+    providers (openrouter, ollama, google, …) are assumed usable: they are
+    deliberate user choices the engine must not clobber.
+    """
+    p = str(provider or "").lower()
+    if p == "anthropic":
+        return has_anthropic_key
+    if p == "openai":
+        return has_openai_key
+    if p == "perplexity":
+        return has_perplexity_key
+    if p == "claude-code":
+        return has_claude
+    if p == "codex-cli":
+        return has_codex
+    return True
+
+
+def _is_stock_taskmaster_default(role: object) -> bool:
+    if not isinstance(role, dict) or not role:
+        return False
+    return (str(role.get("provider", "")).lower(), role.get("modelId")) in KNOWN_STOCK_TASKMASTER_DEFAULTS
 
 
 def _resolve_configure_profile(economy: str | None) -> dict:
@@ -169,11 +217,32 @@ def run_configure_providers(economy: str | None = None) -> dict:
     has_claude = shutil.which("claude") is not None
     has_codex = shutil.which("codex") is not None
     has_anthropic_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
+    has_openai_key = bool(os.environ.get("OPENAI_API_KEY"))
+    has_perplexity_key = _has_perplexity_api_key()
+
+    def _correctable(role: object) -> bool:
+        """A role the engine may (re)write: empty, OR a stock TaskMaster default
+        whose provider is unusable here. Usable configs and genuine user choices
+        are left untouched."""
+        if _role_empty(role):
+            return True
+        if _is_stock_taskmaster_default(role) and not _provider_usable(
+            role.get("provider") if isinstance(role, dict) else None,
+            has_claude=has_claude,
+            has_codex=has_codex,
+            has_anthropic_key=has_anthropic_key,
+            has_openai_key=has_openai_key,
+            has_perplexity_key=has_perplexity_key,
+        ):
+            return True
+        return False
 
     desired_main = _desired_main_model(has_claude, has_codex, has_anthropic_key)
     start_tier = profile.get("structured_gen_start", "standard")
     current_main = models.get("main")
-    if _role_empty(current_main):
+    if _correctable(current_main):
+        # Provider decision dominates the tier decision (P1-4): resolve a usable
+        # provider first, then apply the economy tier on top of it.
         if desired_main:
             models["main"] = _main_model_for_start_tier(desired_main, start_tier)
             changed.append("main")
@@ -187,7 +256,7 @@ def run_configure_providers(economy: str | None = None) -> dict:
             result_extra["skipped_main"] = "user-configured"
 
     desired_fallback = _desired_fallback_model(has_claude, has_codex, has_anthropic_key)
-    if desired_fallback and _role_empty(models.get("fallback")):
+    if desired_fallback and _correctable(models.get("fallback")):
         models["fallback"] = desired_fallback
         changed.append("fallback")
 
@@ -204,10 +273,9 @@ def run_configure_providers(economy: str | None = None) -> dict:
         or "localhost:8765" in local_proxy_url
         or _local_port_open()
     )
-    if _role_empty(models.get("research")):
+    if _correctable(models.get("research")):
         desired_research = None
         research_choice = profile.get("research_choice", "real_api_if_key")
-        has_perplexity_key = _has_perplexity_api_key()
         if research_choice == "real_api_if_key" and has_perplexity_key:
             desired_research = _perplexity_research_model("sonar")
         elif research_choice == "best_available" and has_perplexity_key:

--- a/prd_taskmaster/providers.py
+++ b/prd_taskmaster/providers.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 from prd_taskmaster.economy import TIER_MODEL_IDS, economy_profile
@@ -102,6 +103,47 @@ def _is_stock_taskmaster_default(role: object) -> bool:
     if not isinstance(role, dict) or not role:
         return False
     return (str(role.get("provider", "")).lower(), role.get("modelId")) in KNOWN_STOCK_TASKMASTER_DEFAULTS
+
+
+# Providers that run by spawning a local CLI child (no API key / HTTP). Inside a
+# nested Claude Code session the recursive `claude -p` spawn is refused on SOME
+# Claude versions (gh #11) and works on others — so we PROBE it, never assume.
+_SPAWNING_PROVIDERS = {"claude-code", "codex-cli", "gemini-cli"}
+_SPAWN_PROBE_CLI = {"claude-code": "claude", "codex-cli": "codex", "gemini-cli": "gemini"}
+_SPAWN_PROBE_TIMEOUT = 60
+
+
+def _is_nested_claude() -> bool:
+    """Are we running inside another Claude Code / MCP session? Gate on the strong
+    signals (CLAUDECODE / CLAUDE_CODE_CHILD_SESSION); CLAUDE_CODE_ENTRYPOINT alone
+    can be 'sdk'/'mcp' in non-nested contexts, so it is not used as a primary."""
+    return bool(os.environ.get("CLAUDECODE") or os.environ.get("CLAUDE_CODE_CHILD_SESSION"))
+
+
+def _is_spawning_provider(provider: object) -> bool:
+    return str(provider or "").lower() in _SPAWNING_PROVIDERS
+
+
+def _probe_spawn(provider: object) -> bool:
+    """Actually verify a CLI-spawning provider can run a child here. Returns True
+    when it can (or when it is not a spawning provider). Catches the nested-session
+    spawn refusal empirically instead of assuming it (which would wrongly reroute
+    off the free subscription path on versions where nested spawn works)."""
+    cli = _SPAWN_PROBE_CLI.get(str(provider or "").lower())
+    if not cli:
+        return True
+    binary = shutil.which(cli)
+    if not binary:
+        return False
+    try:
+        if cli == "claude":
+            probe = [binary, "-p", "ok"]
+        else:
+            probe = [binary, "--version"]
+        result = subprocess.run(probe, capture_output=True, text=True, timeout=_SPAWN_PROBE_TIMEOUT)
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
 
 
 def _resolve_configure_profile(economy: str | None) -> dict:

--- a/prd_taskmaster/tm_parallel.py
+++ b/prd_taskmaster/tm_parallel.py
@@ -328,11 +328,17 @@ def _default_concurrency(concurrency: int | None, workdir_count: int, fleet_conf
 _append_telemetry = append_telemetry
 
 
-def _run_one_attempt(binary: str, task_id: Any, workdir: Path, timeout: float) -> tuple[Any, int, str, str]:
+def _run_one_attempt(
+    binary: str, task_id: Any, workdir: Path, timeout: float, research: bool = True
+) -> tuple[Any, int, str, str]:
     start = time.monotonic()
+    args = [binary, "expand", "--id", str(task_id)]
+    if research:
+        args.append("--research")
+    args.append("--force")
     try:
         result = subprocess.run(
-            [binary, "expand", "--id", str(task_id), "--research", "--force"],
+            args,
             cwd=workdir,
             capture_output=True,
             text=True,
@@ -397,6 +403,45 @@ def _run_packet(binary: str, item: dict, timeout: float, fleet_config: dict, pro
             }
         if not can_escalate or attempt == 1:
             break
+
+    # All research-backed attempts failed (e.g. research provider out of quota /
+    # auth down). Degrade to a structural expand (no --research): it does not
+    # depend on the research provider and is always available. A structurally
+    # expanded task is still verifiable — far better than 0 subtasks.
+    exit_code, wall_ms, stdout, stderr = _run_one_attempt(
+        binary, task_id, workdir, timeout, research=False
+    )
+    _append_telemetry({
+        "ts": _now_iso(),
+        "op_class": "structured_gen",
+        "task_id": task_id,
+        "model": model,
+        "backend": "taskmaster-api",
+        "exit": exit_code,
+        "wall_ms": wall_ms,
+        "escalated": False,
+        "degraded": True,
+    })
+    attempts.append({
+        "attempt": len(attempts),
+        "exit": exit_code,
+        "wall_ms": wall_ms,
+        "model": model,
+        "stdout": stdout,
+        "stderr": stderr,
+        "research": False,
+    })
+    if exit_code == 0:
+        return {
+            "task_id": task_id,
+            "exit": 0,
+            "wall_ms": sum(a["wall_ms"] for a in attempts),
+            "attempts": len(attempts),
+            "path": str(workdir),
+            "model": model,
+            "success": True,
+            "degraded": True,
+        }
 
     return {
         "task_id": task_id,

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -264,3 +264,56 @@ def test_taskmaster_responses_carry_backend_identity(tmp_path, monkeypatch):
         assert res.get('ok') is False
         assert res.get('backend') == 'taskmaster'
         assert res.get('ai') == 'taskmaster-cli'
+
+
+# ── pre-relaunch P0-3 (serial path) + P1-1 (parse zero-task) ────────────────
+
+def test_expand_serial_degrades_to_structural_on_research_failure(tmp_path, monkeypatch):
+    """Serial (<=3 tasks) path: when expand --research fails (research provider down),
+    retry without --research rather than hard-failing to 0 subtasks. (P0-3)"""
+    from prd_taskmaster.backend import get_backend
+
+    bin_dir = _isolate(tmp_path, monkeypatch, with_binary=False)
+    script = bin_dir / "task-master"
+    script.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "--version" ]; then echo 0.43.1; exit 0; fi\n'
+        'for a in "$@"; do if [ "$a" = "--research" ]; then echo "quota" >&2; exit 1; fi; done\n'
+        "exit 0\n"
+    )
+    script.chmod(0o755)
+    _seed_tasks(tmp_path, 2)
+
+    result = get_backend({"backend": "taskmaster"}).expand(tag="master")
+
+    assert result["ok"] is True
+    assert result["expanded"] == [1, 2]
+    assert result.get("degraded") is True
+
+
+def test_parse_prd_zero_tasks_is_failure(tmp_path, monkeypatch):
+    """parse-prd that exits 0 but produces no tasks must be reported ok=False, not a
+    silent success that the pipeline treats as done. (P1-1)"""
+    from prd_taskmaster.backend import get_backend
+
+    bin_dir = _isolate(tmp_path, monkeypatch, with_binary=False)
+    script = bin_dir / "task-master"
+    script.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "--version" ]; then echo 0.43.1; exit 0; fi\n'
+        'echo "parsed nothing"\n'
+        "exit 0\n"
+    )
+    script.chmod(0o755)
+    tm = tmp_path / ".taskmaster"
+    (tm / "tasks").mkdir(parents=True, exist_ok=True)
+    (tm / "state.json").write_text(json.dumps({"currentTag": "master"}))
+    # parse-prd exits 0 but the model produced no tasks
+    (tm / "tasks" / "tasks.json").write_text(json.dumps({"master": {"tasks": []}}))
+    prd = tmp_path / "prd.md"
+    prd.write_text("# PRD\n")
+
+    result = get_backend({"backend": "taskmaster"}).parse_prd(prd, 5)
+
+    assert result["ok"] is False
+    assert result["task_count"] == 0

--- a/tests/core/test_capabilities.py
+++ b/tests/core/test_capabilities.py
@@ -201,26 +201,30 @@ class TestValidateSetup:
         assert result["ready"] is False
 
     def test_validate_setup_passes_with_full_project(self, monkeypatch, tmp_path):
-        """ready=True when CLI exists, project initialized, and main model configured."""
+        """ready=True when CLI exists, project initialized, and the main model's
+        provider is genuinely reachable (a real provider + a usable credential —
+        not merely a model-id string)."""
         # Create fake task-master binary
         fake_bin = tmp_path / "bin" / "task-master"
         fake_bin.parent.mkdir(parents=True)
         fake_bin.write_text("#!/bin/sh\necho 0.99.0\n")
         fake_bin.chmod(0o755)
 
-        # Create .taskmaster/ with config.json
+        # Create .taskmaster/ with config.json — providers named, and a credential
+        # present so the gate's reachability check passes for the right reason.
         tm_dir = tmp_path / "project" / ".taskmaster"
         tm_dir.mkdir(parents=True)
         config = {
             "models": {
-                "main": {"modelId": "claude-sonnet-4-5"},
-                "research": {"modelId": "claude-opus-4"},
-                "fallback": {"modelId": "claude-haiku-3"},
+                "main": {"provider": "anthropic", "modelId": "claude-sonnet-4-5"},
+                "research": {"provider": "anthropic", "modelId": "claude-opus-4"},
+                "fallback": {"provider": "anthropic", "modelId": "claude-haiku-3"},
             }
         }
         (tm_dir / "config.json").write_text(json.dumps(config))
 
         monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         monkeypatch.chdir(tmp_path / "project")
 
         result = validate_setup()

--- a/tests/core/test_prerelaunch_p0_fixes.py
+++ b/tests/core/test_prerelaunch_p0_fixes.py
@@ -15,6 +15,7 @@ default", which is the exact state `task-master init` creates.
 import json
 from pathlib import Path
 
+from prd_taskmaster.mode_recommend import validate_setup
 from prd_taskmaster.providers import run_configure_providers
 
 
@@ -98,3 +99,56 @@ def test_configure_preserves_usable_stock_anthropic_when_key_present(tmp_path, m
 
     assert result["models"]["main"]["provider"] == "anthropic"
     assert "main" not in result["changed"]
+
+
+# ── P0-2: SETUP gate must be credential-aware, not string-presence ───────────
+
+def _patch_setup_env(monkeypatch, *, claude=False, codex=False):
+    """Make the task-master binary check pass while controlling CLI/key availability
+    for the provider-usability checks."""
+    def fake_which(name: str) -> str | None:
+        if "task-master" in name or name == "taskmaster":
+            return "/fake/bin/task-master"
+        if name == "claude" and claude:
+            return "/fake/bin/claude"
+        if name == "codex" and codex:
+            return "/fake/bin/codex"
+        return None
+
+    monkeypatch.setattr("prd_taskmaster.mode_recommend.shutil.which", fake_which)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+
+
+def test_validate_setup_fails_on_keyless_paid_main_provider(tmp_path, monkeypatch):
+    """The gate green-lit the exact 0-task config: a paid 'anthropic' main with no
+    ANTHROPIC_API_KEY and no claude/codex CLI. A model-id string is present but the
+    provider cannot run — ready must be False with a critical failure."""
+    monkeypatch.chdir(tmp_path)
+    _patch_setup_env(monkeypatch, claude=False, codex=False)
+    _seed_taskmaster_config(tmp_path, {k: dict(v) for k, v in STOCK_PAID_DEFAULTS.items()})
+
+    result = validate_setup()
+
+    main_check = next(c for c in result["checks"] if c["id"] == "provider_main")
+    assert main_check["passed"] is False
+    assert result["ready"] is False
+    assert result["critical_failures"] >= 1
+    assert main_check["fix"]  # actionable remediation present
+
+
+def test_validate_setup_passes_when_main_provider_is_usable(tmp_path, monkeypatch):
+    """The corrected free config (main on the claude CLI) must pass the gate."""
+    monkeypatch.chdir(tmp_path)
+    _patch_setup_env(monkeypatch, claude=True, codex=True)
+    _seed_taskmaster_config(tmp_path, {
+        "main": {"provider": "claude-code", "modelId": "sonnet"},
+        "research": {"provider": "claude-code", "modelId": "sonnet"},
+        "fallback": {"provider": "codex-cli", "modelId": "gpt-5.2-codex"},
+    })
+
+    result = validate_setup()
+
+    main_check = next(c for c in result["checks"] if c["id"] == "provider_main")
+    assert main_check["passed"] is True
+    assert result["ready"] is True

--- a/tests/core/test_prerelaunch_p0_fixes.py
+++ b/tests/core/test_prerelaunch_p0_fixes.py
@@ -1,0 +1,100 @@
+"""Pre-relaunch P0 regression tests (docs/audit/AUDIT.md, 2026-06-14).
+
+These encode the three first-run blockers found by the pre-relaunch audit, each
+reproduced firsthand against the 5.2.0 first-run path:
+
+  P0-1  configure-providers no-op on TaskMaster's stock paid defaults
+  P0-2  SETUP gate reports ready=True for a keyless (0-task) config
+  P0-3  expand hard-fails when research provider is down (no structural degrade)
+
+The unifying bias they correct: the prior suite only asserted "leave the user's
+config alone" against EMPTY/customized baselines — never "CORRECT a keyless stock
+default", which is the exact state `task-master init` creates.
+"""
+
+import json
+from pathlib import Path
+
+from prd_taskmaster.providers import run_configure_providers
+
+
+# ── shared fixtures (self-contained; mirror test_dogfood_fixes helpers) ──────
+
+# The exact roles `task-master init` writes by default (the real dogfood config).
+STOCK_PAID_DEFAULTS = {
+    "main": {
+        "provider": "anthropic",
+        "modelId": "claude-sonnet-4-20250514",
+        "maxTokens": 64000,
+        "temperature": 0.2,
+    },
+    "research": {
+        "provider": "perplexity",
+        "modelId": "sonar",
+        "maxTokens": 8700,
+        "temperature": 0.1,
+    },
+    "fallback": {
+        "provider": "anthropic",
+        "modelId": "claude-3-7-sonnet-20250219",
+        "maxTokens": 120000,
+        "temperature": 0.2,
+    },
+}
+
+
+def _seed_taskmaster_config(root: Path, models: dict) -> None:
+    taskmaster = root / ".taskmaster"
+    taskmaster.mkdir(exist_ok=True)
+    (taskmaster / "config.json").write_text(json.dumps({"models": models}, indent=2))
+
+
+def _patch_env(monkeypatch, *, claude: bool = False, codex: bool = False) -> None:
+    def fake_which(name: str) -> str | None:
+        if name == "claude" and claude:
+            return "/fake/bin/claude"
+        if name == "codex" and codex:
+            return "/fake/bin/codex"
+        return None
+
+    monkeypatch.setattr("prd_taskmaster.providers.shutil.which", fake_which)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.delenv("PERPLEXITY_API_BASE_URL", raising=False)
+    monkeypatch.delenv("PERPLEXITY_API_FREE_BASE_URL", raising=False)
+
+
+# ── P0-1: configure must REPAIR keyless stock paid defaults ──────────────────
+
+def test_configure_repairs_keyless_stock_paid_trio_to_free_clis(tmp_path, monkeypatch):
+    """The dogfood failure: init writes the paid anthropic+perplexity trio, the user
+    has no ANTHROPIC_API_KEY/PERPLEXITY_API_KEY but DOES have the claude+codex CLIs.
+    configure-providers must migrate all three unusable roles to the free paths, not
+    no-op on them (which left the first run producing 0 tasks)."""
+    monkeypatch.chdir(tmp_path)
+    _patch_env(monkeypatch, claude=True, codex=True)
+    _seed_taskmaster_config(tmp_path, {k: dict(v) for k, v in STOCK_PAID_DEFAULTS.items()})
+
+    result = run_configure_providers(economy="balanced")
+
+    assert result["models"]["main"]["provider"] == "claude-code"
+    assert result["models"]["fallback"]["provider"] == "codex-cli"
+    # dead paid Perplexity (no key) must yield to the free local proxy
+    assert result["models"]["research"]["provider"] == "openai-compatible"
+    assert "main" in result["changed"]
+    assert "fallback" in result["changed"]
+    assert "research" in result["changed"]
+
+
+def test_configure_preserves_usable_stock_anthropic_when_key_present(tmp_path, monkeypatch):
+    """Repair is scoped to UNUSABLE roles: a stock anthropic main WITH a real key is a
+    working config — leave its provider alone (don't yank a paying user onto the CLI)."""
+    monkeypatch.chdir(tmp_path)
+    _patch_env(monkeypatch, claude=True, codex=True)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real")
+    _seed_taskmaster_config(tmp_path, {"main": dict(STOCK_PAID_DEFAULTS["main"])})
+
+    result = run_configure_providers(economy="balanced")
+
+    assert result["models"]["main"]["provider"] == "anthropic"
+    assert "main" not in result["changed"]

--- a/tests/core/test_prerelaunch_p0_fixes.py
+++ b/tests/core/test_prerelaunch_p0_fixes.py
@@ -267,3 +267,46 @@ def test_validate_setup_passes_when_nested_claude_code_spawn_probe_succeeds(tmp_
     main_check = next(c for c in result["checks"] if c["id"] == "provider_main")
     assert main_check["passed"] is True
     assert result["ready"] is True
+
+
+# ── #13: preflight flags a stale (all-done) tag + suggests a fresh one ───────
+
+def test_preflight_flags_stale_tag_and_suggests_fresh(tmp_path, monkeypatch):
+    """A non-empty but fully-done current tag is 'stale': parsing a new PRD into it
+    would pollute the old graph. preflight must flag it and suggest a fresh tag."""
+    from prd_taskmaster.pipeline import preflight
+
+    monkeypatch.chdir(tmp_path)
+    tm = tmp_path / ".taskmaster"
+    (tm / "docs").mkdir(parents=True)
+    (tm / "tasks").mkdir(parents=True)
+    (tm / "docs" / "prd.md").write_text("# New PRD\n")
+    (tm / "state.json").write_text('{"currentTag":"master"}')
+    (tm / "tasks" / "tasks.json").write_text(
+        '{"master":{"tasks":[{"id":1,"title":"old","status":"done"}]}}'
+    )
+
+    result = preflight()
+
+    assert result["current_tag_stale"] is True
+    assert result["suggested_fresh_tag"]
+    assert result["suggested_fresh_tag"] != "master"
+
+
+def test_preflight_not_stale_when_pending_work_remains(tmp_path, monkeypatch):
+    from prd_taskmaster.pipeline import preflight
+
+    monkeypatch.chdir(tmp_path)
+    tm = tmp_path / ".taskmaster"
+    (tm / "docs").mkdir(parents=True)
+    (tm / "tasks").mkdir(parents=True)
+    (tm / "docs" / "prd.md").write_text("# PRD\n")
+    (tm / "state.json").write_text('{"currentTag":"master"}')
+    (tm / "tasks" / "tasks.json").write_text(
+        '{"master":{"tasks":[{"id":1,"title":"todo","status":"pending"}]}}'
+    )
+
+    result = preflight()
+
+    assert result["current_tag_stale"] is False
+    assert result["suggested_fresh_tag"] is None

--- a/tests/core/test_prerelaunch_p0_fixes.py
+++ b/tests/core/test_prerelaunch_p0_fixes.py
@@ -13,10 +13,12 @@ default", which is the exact state `task-master init` creates.
 """
 
 import json
+import stat
 from pathlib import Path
 
 from prd_taskmaster.mode_recommend import validate_setup
 from prd_taskmaster.providers import run_configure_providers
+from prd_taskmaster.tm_parallel import _run_packet
 
 
 # ── shared fixtures (self-contained; mirror test_dogfood_fixes helpers) ──────
@@ -152,3 +154,57 @@ def test_validate_setup_passes_when_main_provider_is_usable(tmp_path, monkeypatc
     main_check = next(c for c in result["checks"] if c["id"] == "provider_main")
     assert main_check["passed"] is True
     assert result["ready"] is True
+
+
+# ── P0-3: expand must degrade to structural when research provider is down ───
+
+def _fake_research_sensitive_taskmaster(bin_dir: Path) -> str:
+    """A fake `task-master` that FAILS when --research is present (quota/auth down)
+    and SUCCEEDS for a structural expand. Returns the binary path."""
+    script = bin_dir / "task-master"
+    script.write_text(
+        "#!/bin/sh\n"
+        'for a in "$@"; do\n'
+        '  if [ "$a" = "--research" ]; then echo "Perplexity API error: quota" >&2; exit 1; fi\n'
+        "done\n"
+        "exit 0\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return str(script)
+
+
+def test_expand_packet_degrades_to_structural_on_research_failure(tmp_path):
+    """The dogfood outage: research provider out of quota. expand --research fails;
+    the engine must retry WITHOUT --research (structural, 'always available') rather
+    than hard-fail to 0 subtasks. Success is marked degraded."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    binary = _fake_research_sensitive_taskmaster(bin_dir)
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+
+    item = {"task_id": 1, "path": str(workdir), "tier": "standard", "model": "sonnet"}
+    profile = {"structured_gen_start": "standard", "escalation": {"enabled": False}}
+
+    result = _run_packet(binary, item, timeout=30, fleet_config={}, profile=profile)
+
+    assert result["success"] is True
+    assert result.get("degraded") is True
+
+
+def test_expand_packet_fails_when_structural_also_fails(tmp_path):
+    """If even structural expand fails, the packet is a genuine failure (not masked)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    script = bin_dir / "task-master"
+    script.write_text("#!/bin/sh\necho 'hard failure' >&2\nexit 1\n")
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+
+    item = {"task_id": 1, "path": str(workdir), "tier": "standard", "model": "sonnet"}
+    profile = {"structured_gen_start": "standard", "escalation": {"enabled": False}}
+
+    result = _run_packet(str(script), item, timeout=30, fleet_config={}, profile=profile)
+
+    assert result["success"] is False

--- a/tests/core/test_prerelaunch_p0_fixes.py
+++ b/tests/core/test_prerelaunch_p0_fixes.py
@@ -120,6 +120,9 @@ def _patch_setup_env(monkeypatch, *, claude=False, codex=False):
     monkeypatch.setattr("prd_taskmaster.mode_recommend.shutil.which", fake_which)
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    # base setup tests are non-nested + deterministic; nested tests opt in explicitly
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_CHILD_SESSION", raising=False)
 
 
 def test_validate_setup_fails_on_keyless_paid_main_provider(tmp_path, monkeypatch):
@@ -208,3 +211,59 @@ def test_expand_packet_fails_when_structural_also_fails(tmp_path):
     result = _run_packet(str(script), item, timeout=30, fleet_config={}, profile=profile)
 
     assert result["success"] is False
+
+
+# ── #11/#12: nested-session spawn PROBE (verify, don't assume) ───────────────
+
+def test_is_nested_claude_detects_env(monkeypatch):
+    from prd_taskmaster.providers import _is_nested_claude
+
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_CHILD_SESSION", raising=False)
+    assert _is_nested_claude() is False
+
+    monkeypatch.setenv("CLAUDECODE", "1")
+    assert _is_nested_claude() is True
+
+
+def test_validate_setup_fails_when_nested_claude_code_spawn_probe_fails(tmp_path, monkeypatch):
+    """#11/#12: if the claude-code main provider genuinely cannot spawn in this nested
+    session (probe fails), the gate must fail with an actionable error — NOT silently
+    pass and let parse_prd die with exit 1 / no tasks. (Probe, not assume.)"""
+    monkeypatch.chdir(tmp_path)
+    _patch_setup_env(monkeypatch, claude=True, codex=True)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setattr("prd_taskmaster.mode_recommend._probe_spawn", lambda provider: False)
+    _seed_taskmaster_config(tmp_path, {
+        "main": {"provider": "claude-code", "modelId": "sonnet"},
+        "research": {"provider": "perplexity", "modelId": "sonar"},
+        "fallback": {"provider": "codex-cli", "modelId": "gpt-5.2-codex"},
+    })
+
+    result = validate_setup()
+
+    main_check = next(c for c in result["checks"] if c["id"] == "provider_main")
+    assert main_check["passed"] is False
+    assert result["ready"] is False
+    assert "--claude-code" not in (main_check["fix"] or "")
+    assert "nest" in (main_check["detail"] or "").lower()
+
+
+def test_validate_setup_passes_when_nested_claude_code_spawn_probe_succeeds(tmp_path, monkeypatch):
+    """The contradicting case: nested but claude-code spawns fine (current versions).
+    The gate must NOT regress the free working path to a forced reroute."""
+    monkeypatch.chdir(tmp_path)
+    _patch_setup_env(monkeypatch, claude=True, codex=True)
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setattr("prd_taskmaster.mode_recommend._probe_spawn", lambda provider: True)
+    _seed_taskmaster_config(tmp_path, {
+        "main": {"provider": "claude-code", "modelId": "sonnet"},
+        "research": {"provider": "perplexity", "modelId": "sonar"},
+        "fallback": {"provider": "claude-code", "modelId": "sonnet"},
+    })
+
+    result = validate_setup()
+
+    main_check = next(c for c in result["checks"] if c["id"] == "provider_main")
+    assert main_check["passed"] is True
+    assert result["ready"] is True

--- a/tests/core/test_tm_parallel.py
+++ b/tests/core/test_tm_parallel.py
@@ -194,15 +194,20 @@ def test_tm_run_failure_retries_with_escalated_config_and_telemetry(tmp_path, mo
 
     assert run["ok"] is False
     assert run["failed"] == [1]
-    assert run["results"][0]["attempts"] == 2
+    # 2 research-backed attempts (one escalated) + 1 structural degrade attempt.
+    # The structural fallback (P0-3) means a research outage no longer ends at 2
+    # research failures — it always tries a no---research pass before giving up.
+    assert run["results"][0]["attempts"] == 3
     workdir = Path(plan["workdirs"][0]["path"])
     config = _read_json(workdir / ".taskmaster" / "config.json")
     assert config["models"]["main"]["provider"] == "anthropic"
     assert config["models"]["main"]["modelId"] == tm_parallel.TIER_MODEL_IDS["opus"]
     rows = [json.loads(line) for line in Path(".atlas-ai/telemetry.jsonl").read_text().splitlines()]
-    assert [row["task_id"] for row in rows] == [1, 1]
+    assert [row["task_id"] for row in rows] == [1, 1, 1]
     assert rows[0]["exit"] == 1
     assert rows[1]["escalated"] is True
+    # final row is the structural (no-research) degrade attempt
+    assert rows[2].get("degraded") is True
 
 
 def test_tm_run_timeout_records_failure_and_retains_workdir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Pre-relaunch P0 hardening → 5.2.1

A multi-agent, evidence-based audit (verdict **HOLD**, see `docs/audit/AUDIT.md`) found the engine's headline promise — *"zero setup, no paid API key, uses the CLIs you already have"* — was **broken on the documented first-run path**, and the SETUP gate green-lit the broken state. All three P0s were **reproduced firsthand** and are fixed here, TDD, with two live dogfood signals confirming them.

### The P0 causal chain (all fixed)
- **P0-1** — `configure-providers` only filled *empty* model roles, so `task-master init`'s stock paid `anthropic`+`perplexity` defaults survived and a keyless first run produced **0 tasks**. Now it *repairs* any stock default whose provider is unusable in-env → free `claude`/`codex` CLI or local proxy. (`fb9d4f7`)
- **P0-2** — `validate_setup` reported `ready=True` on any model-id string; now credential-/CLI-aware. (`9bec1b2`)
- **P0-3** — `expand` hardcoded `--research`; a research-provider outage hard-failed to 0 subtasks. Now degrades to a structural pass (parallel + serial), marked `degraded`. **+ P1-1** `parse_prd` 0-task = failure (was silent success). (`bf1bc59`)

### From the 2nd dogfood (atlas-ai-website issues #11–#13)
- **#11/#12** — the filed claim (nested `claude-code` spawn always fails) was **refuted by direct probe** (claude 2.1.177 spawns nested fine; parse made 20 tasks at $0). Instead of the regression-causing forced reroute, the gate now **probes** the spawn — keeps the free path when it works, surfaces an actionable error when it genuinely fails. (`c924112`)
- **#13** — `preflight` flags `current_tag_stale` + `suggested_fresh_tag`. (`a182d91`)

### Why the green suite shipped this
The prior 318 tests only asserted *"leave the user's config alone"* against EMPTY baselines — never *"CORRECT a keyless stock default"*, the exact state `task-master init` creates. This PR adds the missing regression tests (`tests/core/test_prerelaunch_p0_fixes.py`) and corrects an anti-regression lock in `test_tm_parallel.py` that had encoded the broken behavior.

### Verification
- **331 tests pass** (`pytest tests/`), CLI + MCP surfaces (server.py delegates to `prd_taskmaster/`).
- **Dogfood replay:** `shade-browser-mcp` went from **0 → 20 tasks** at **$0** via free `claude-code`.
- Audit artifacts included under `docs/audit/`.

### Not in scope (tracked follow-ups)
Remaining non-blocking audit items: `get_backend` default-to-native, research routing P1-2/3/8, skill/MCP dead refs P1-5/6, concurrent-apply P1-7, `.env`/`.gitignore` hygiene (#14), and a separate upstream quirk where `task-master expand` exits 0 but persists 0 subtasks under claude-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
