### PR TITLE
release: 5.3.0 — unfakable done + settled tournament + first-run UX

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "Zero-config goal-to-tasks engine for Claude Code (the Atlas engine). Graded PRD validation, dependency-ordered task graph, and CDD-verified execution.",
   "author": {
     "name": "Atlas AI",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to this project are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0] — 2026-06-17
+
+The "unfakable done" release: a task ships only when its test genuinely re-ran green AND
+the code it tested is wired in — and that trustworthy signal now drives a competitive
+marketplace. Consolidates the oracle + reachability gates, the settled tournament, and the
+dogfooded first-run UX into one engine.
+
+### Added
+- **Re-execution oracle (ship-check Gate 5)** — re-grades each "done" task by re-running the
+  operator-held tests at the claimed commit in a network-isolated, digest-pinned podman
+  sandbox. A submitter can no longer pass by editing their own logs; the self-grantable
+  `SHIP_CHECK_OVERRIDE_ADMIN` bypass is removed.
+- **Reachability gate (Gate 6)** — `done = oracle-PASS AND the tested code is wired in`. A
+  green test on an orphan module (imported by nothing) is blocked and surfaced as
+  `⚠ scaffolded`.
+- **Settled-tournament marketplace** (`tournament run` / `tournament-status`) — N executors
+  race one job, every submission is adjudicated through both gates, the winner is paid in
+  AtlasCoin, honest losers are refunded, and a trusted reputation store (UCB explore/exploit)
+  routes the next job to the cheapest proven-capable executor. Includes a cheap OpenRouter
+  (goose) racer.
+- **Deterministic `expand-structural`** — decomposes an under-specified task into ≥2
+  verifiable subtasks with no model or network.
+
+### Changed
+- `/atlas` now opens with a **Confirm-Intent / plan-mode gate** before any file is written,
+  and gate prompts are harness-adaptive (AskUserQuestion on Claude Code; nearest equivalent
+  on codex/gemini).
+- `task-master-ai` is now **optional** (the native engine stands alone); the
+  `tm-parallel`/`tm-plan`/`tm-run`/`tm-harvest` surfaces were removed.
+- Fakery is **shadow-logged only** this release — proven cheating is recorded, no AtlasCoin is
+  burned, and honest losers always get their stake back.
+
+### Fixed
+- Preflight `configure` no longer silently no-ops on a fresh project (returns an explicit
+  "configuration deferred").
+- `tournament settle` always returns a parseable `{ok, stage}` envelope (no empty stdout on a
+  bad job dir); settlement is crash-resumable (no paid-but-stuck winner).
+- The cheap (goose) racer is no longer falsely rejected on non-ASCII diffs; tournament racers
+  are wired to the real orchestrator inbox.
+- AtlasCoin is conserved (no mint/burn) under account aliasing.
+
+### Tests
+- 872 passing + 4 real-podman e2e gates green (oracle dogfood + tournament settle/pay/reputation).
+
 ## [5.2.2] — 2026-06-14
 
 Front-door UX flow fixes (a UX-flow audit found the *journey* still broke before a

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 REPO_OWNER="anombyte93"
 REPO_NAME="prd-taskmaster"
 SKILL_NAME="prd-taskmaster"
-VERSION="5.2.2"
+VERSION="5.3.0"
 SKILL_DIR="${SKILL_DIR:-${HOME}/.claude/skills/${SKILL_NAME}}"
 ALIAS_NAME="atlas"
 ALIAS_DIR="${HOME}/.claude/skills/${ALIAS_NAME}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-taskmaster",
-  "version": "5.2.2",
+  "version": "5.3.0",
   "description": "Zero-config goal-to-tasks engine for Claude Code (the Atlas engine)",
   "author": {
     "name": "Atlas AI",

--- a/prd_taskmaster/__init__.py
+++ b/prd_taskmaster/__init__.py
@@ -1,3 +1,3 @@
 """prd-taskmaster: zero-config goal-to-tasks engine (deterministic CLI core)."""
 
-__version__ = "5.2.2"
+__version__ = "5.3.0"


### PR DESCRIPTION
Cuts **5.3.0** for the /atlas catch-up already merged to `main` (PR #23). Bumps the four version sources (`__init__.py`, `package.json`, `.claude-plugin/plugin.json`, `install.sh`) to 5.3.0 and adds the `## [5.3.0]` CHANGELOG entry.

Minor-version content (oracle Gate 5 + reachability Gate 6 + the settled-tournament marketplace + first-run UX). version-agreement check passes locally (all four agree + CHANGELOG has 5.3.0); 58 manifest/plugin tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)